### PR TITLE
feat: Add export functionality for all courses as ZIP and update routes

### DIFF
--- a/src/Modules/Academic/GenerateStudentList.jsx
+++ b/src/Modules/Academic/GenerateStudentList.jsx
@@ -22,10 +22,11 @@ import axios from "axios";
 import { showNotification } from "@mantine/notifications";
 
 import {
-  availableCoursesRoute,   // NEW endpoint: GET /aims/api/available-courses/
-  generatexlsheet,         // POST /aims/api/generate-xlsheet/
-  listBatchesRoute,        // Academic procedures API for prereg tab
-  generateprereport,       // unchanged: for prereg tab
+  availableCoursesRoute,
+  generatexlsheet,
+  exportAllCoursesZipRoute,
+  listBatchesRoute,
+  generateprereport,
 } from "../../routes/academicRoutes";
 
 const generateAcademicYears = () => {
@@ -88,6 +89,7 @@ export default function GenerateStudentList() {
 
   const [loading, setLoading]           = useState(false);
   const [error, setError]               = useState(null);
+  const [exportAllLoading, setExportAllLoading] = useState(false);
 
   // 1) Fetch available courses once year+semester are set
   const fetchCourses = useCallback(async () => {
@@ -183,7 +185,39 @@ export default function GenerateStudentList() {
     }
   };
 
-  // 3) Generate Roll List Excel
+  // 3) Export ALL courses as ZIP
+  const handleExportAllZip = async () => {
+    setExportAllLoading(true);
+    const token = localStorage.getItem("authToken");
+    try {
+      const payload = { academic_year: academicYear, semester_type: semesterType };
+      if (listType && listType.trim()) payload.list_type = listType;
+      if (programmeType && programmeType !== "All") payload.programme_type = programmeType;
+
+      const res = await axios.post(exportAllCoursesZipRoute, payload, {
+        headers: { Authorization: `Token ${token}`, "Content-Type": "application/json" },
+        responseType: "blob",
+      });
+
+      const filename = `${academicYear.replace("-", "_")}_${semesterType.replace(/ /g, "_")}_All_Courses.zip`;
+      const url = window.URL.createObjectURL(new Blob([res.data]));
+      const a = document.createElement("a");
+      a.href = url;
+      a.setAttribute("download", filename);
+      document.body.appendChild(a);
+      a.click();
+      a.remove();
+      window.URL.revokeObjectURL(url);
+
+      showNotification({ title: "Downloaded", message: `${courseOptions.length} courses exported as ZIP`, color: "green" });
+    } catch (err) {
+      showNotification({ title: "Export failed", message: err.response?.data?.error || err.message, color: "red" });
+    } finally {
+      setExportAllLoading(false);
+    }
+  };
+
+  // 4) Generate Roll List Excel
   const handleGenerateList = async () => {
     if (!academicYear || !semesterType || !course) {
       showNotification({
@@ -197,7 +231,7 @@ export default function GenerateStudentList() {
     await handlePreview();
   };
 
-  // 4) Confirm and generate after preview
+  // 5) Confirm and generate after preview
   const handleConfirmGenerate = async () => {
     setLoading(true);
     const token = localStorage.getItem("authToken");
@@ -467,13 +501,27 @@ export default function GenerateStudentList() {
           ) : (
             <Select
               label="Course"
-              placeholder="Select course"
+              placeholder="Select course (leave empty to export all)"
               data={courseOptions}
               value={course}
               onChange={setCourse}
               searchable
+              clearable
               mb="md"
             />
+          )}
+
+          {/* Export All — shown only when courses are loaded and none is selected */}
+          {!course && courseOptions.length > 0 && academicYear && semesterType && (
+            <Button
+              fullWidth
+              color="teal"
+              mb="sm"
+              loading={exportAllLoading}
+              onClick={handleExportAllZip}
+            >
+              Export All ({courseOptions.length} courses) as ZIP
+            </Button>
           )}
 
           <Button

--- a/src/routes/academicRoutes/index.jsx
+++ b/src/routes/academicRoutes/index.jsx
@@ -42,6 +42,7 @@ export const getStudentCourseRoute = `${host}/academic-procedures/api/acad/verif
 export const dropStudentCourseRoute = `${host}/academic-procedures/api/acad/verify_course/drop/`;
 export const addStudentCourseRoute = `${host}/academic-procedures/api/acad/addCourse/`;
 export const generatexlsheet = `${host}/aims/api/generatexlsheet`;
+export const exportAllCoursesZipRoute = `${host}/aims/api/export-all-courses-zip/`;
 export const availableCoursesRoute = `${host}/aims/api/available-courses`;
 export const academicProceduresFaculty = `${host}/academic-procedures/api/fac/academic_procedures_faculty`;
 export const getAllCourses = `${host}/academic-procedures/api/acad/get_all_courses`;


### PR DESCRIPTION
This pull request adds the ability to export all available course roll lists as a ZIP file from the `GenerateStudentList` module. It introduces a new backend route, a UI button for exporting, and supporting logic for handling the request and download. The main changes are grouped below:

**Feature: Export All Courses as ZIP**

* Added a new API route `exportAllCoursesZipRoute` in `academicRoutes` for exporting all courses as a ZIP file.
* Implemented the `handleExportAllZip` function in `GenerateStudentList.jsx` to send a request to the new endpoint, handle the file download, and provide user feedback.
* Introduced a new loading state `exportAllLoading` to manage UI feedback during the export process.
* Updated the course selection UI: the course dropdown is now clearable, and when no course is selected, an "Export All" button appears, allowing users to export all courses as a ZIP.

**Code Cleanup and Consistency**

* Cleaned up the import of routes in `GenerateStudentList.jsx` for consistency and maintainability.