### PR TITLE
feat(placement-cell): Add full Placement Cell module with role-based UI

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -16,6 +16,7 @@ import Examination from "./Modules/Examination/examination";
 import Database from "./Modules/Database/database";
 import ProgrammeCurriculumRoutes from "./Modules/Program_curriculum/programmCurriculum";
 import NotFoundPage from "./components/NotFoundPage";
+import PlacementCell from "./Modules/PlacementCell/index";
 
 const theme = createTheme({
   breakpoints: {
@@ -156,6 +157,14 @@ export default function App() {
             <div>
               <ProgrammeCurriculumRoutes />
             </div>
+          }
+        />
+        <Route
+          path="/placement-cell"
+          element={
+            <Layout>
+              <PlacementCell />
+            </Layout>
           }
         />
         <Route path="/accounts/login" element={<LoginPage />} />

--- a/src/Modules/PlacementCell/api.js
+++ b/src/Modules/PlacementCell/api.js
@@ -1,0 +1,105 @@
+import {
+  STU_DASHBOARD_URL, STU_JOBS_URL, STU_JOB_DETAIL_URL, STU_JOB_APPLY_URL,
+  STU_APPLICATIONS_URL, STU_WITHDRAW_URL, STU_PROFILE_URL,
+  OFC_COMPANIES_URL, OFC_COMPANY_URL, OFC_JOBS_URL, OFC_JOB_URL,
+  OFC_JOB_TOGGLE_URL, OFC_APPLICANTS_URL, OFC_APP_STATUS_URL,
+  OFC_BULK_STATUS_URL, OFC_BATCHES_URL, OFC_STUDENTS_URL, OFC_STUDENT_UPDATE_URL, OFC_EXPORT_URL,
+  OFC_ANNOUNCEMENTS_URL, OFC_ANNOUNCEMENT_URL,
+  OFC_STATS_URL, OFC_STATS_REFRESH_URL, OFC_OFFCAMPUS_URL, OFC_OFFCAMPUS_ITEM_URL,
+  CHM_STATS_URL, CHM_BATCHES_URL, CHM_STUDENTS_URL, CHM_EXPORT_URL,
+  DEAN_BATCHES_URL, DEAN_STATS_URL, DEAN_ANNOUNCEMENTS_URL,
+} from '../../routes/placementRoutes';
+
+const authHeaders = () => ({
+  Authorization: `Token ${localStorage.getItem('authToken')}`,
+  'Content-Type': 'application/json',
+});
+
+const handleResponse = async (res) => {
+  if (!res.ok) {
+    const body = await res.json().catch(() => ({}));
+    // DRF field errors: {field: ["msg"]} — flatten to readable string
+    const msg = body.error || body.detail
+      || Object.entries(body).map(([k, v]) => `${k}: ${Array.isArray(v) ? v.join(', ') : v}`).join(' | ')
+      || `HTTP ${res.status}`;
+    throw new Error(msg);
+  }
+  if (res.status === 204) return null;
+  return res.json();
+};
+
+// ── Student ──────────────────────────────────────────────────────────────────
+export const fetchDashboard   = () => fetch(STU_DASHBOARD_URL,   { headers: authHeaders() }).then(handleResponse);
+export const fetchActiveJobs  = () => fetch(STU_JOBS_URL,         { headers: authHeaders() }).then(handleResponse);
+export const fetchJobDetail   = (id) => fetch(STU_JOB_DETAIL_URL(id), { headers: authHeaders() }).then(handleResponse);
+export const applyToJob       = (id) => fetch(STU_JOB_APPLY_URL(id), { method: 'POST', headers: authHeaders() }).then(handleResponse);
+export const fetchApplications = () => fetch(STU_APPLICATIONS_URL, { headers: authHeaders() }).then(handleResponse);
+export const withdrawApplication = (id) => fetch(STU_WITHDRAW_URL(id), { method: 'POST', headers: authHeaders() }).then(handleResponse);
+export const fetchStudentProfile = () => fetch(STU_PROFILE_URL, { headers: authHeaders() }).then(handleResponse);
+export const updateStudentProfile = (data) => fetch(STU_PROFILE_URL, {
+  method: 'PUT', headers: authHeaders(), body: JSON.stringify(data),
+}).then(handleResponse);
+
+// ── Officer ───────────────────────────────────────────────────────────────────
+export const fetchCompanies   = () => fetch(OFC_COMPANIES_URL, { headers: authHeaders() }).then(handleResponse);
+export const createCompany    = (data) => fetch(OFC_COMPANIES_URL, { method: 'POST', headers: authHeaders(), body: JSON.stringify(data) }).then(handleResponse);
+export const updateCompany    = (id, data) => fetch(OFC_COMPANY_URL(id), { method: 'PUT', headers: authHeaders(), body: JSON.stringify(data) }).then(handleResponse);
+export const deleteCompany    = (id) => fetch(OFC_COMPANY_URL(id), { method: 'DELETE', headers: authHeaders() }).then(handleResponse);
+
+export const fetchAllJobs     = () => fetch(OFC_JOBS_URL, { headers: authHeaders() }).then(handleResponse);
+export const createJobPost    = (data) => fetch(OFC_JOBS_URL, { method: 'POST', headers: authHeaders(), body: JSON.stringify(data) }).then(handleResponse);
+export const updateJobPost    = (id, data) => fetch(OFC_JOB_URL(id), { method: 'PUT', headers: authHeaders(), body: JSON.stringify(data) }).then(handleResponse);
+export const toggleJobPost    = (id) => fetch(OFC_JOB_TOGGLE_URL(id), { method: 'POST', headers: authHeaders() }).then(handleResponse);
+
+export const fetchApplicants  = (jobId) => fetch(OFC_APPLICANTS_URL(jobId), { headers: authHeaders() }).then(handleResponse);
+export const updateAppStatus  = (appId, newStatus) => fetch(OFC_APP_STATUS_URL(appId), {
+  method: 'POST', headers: authHeaders(), body: JSON.stringify({ status: newStatus }),
+}).then(handleResponse);
+export const bulkUpdateStatus = (ids, newStatus) => fetch(OFC_BULK_STATUS_URL, {
+  method: 'POST', headers: authHeaders(), body: JSON.stringify({ ids, status: newStatus }),
+}).then(handleResponse);
+
+export const fetchBatches      = () => fetch(OFC_BATCHES_URL, { headers: authHeaders() }).then(handleResponse);
+export const fetchAllStudents  = (batchId) => fetch(OFC_STUDENTS_URL(batchId), { headers: authHeaders() }).then(handleResponse);
+export const updateStudentByOfficer = (data) => fetch(OFC_STUDENT_UPDATE_URL, {
+  method: 'POST', headers: authHeaders(), body: JSON.stringify(data),
+}).then(handleResponse);
+export const refreshStats      = (batchYear) => fetch(OFC_STATS_REFRESH_URL, {
+  method: 'POST', headers: authHeaders(), body: JSON.stringify({ batch_year: batchYear }),
+}).then(handleResponse);
+
+export const fetchOfficerAnnouncements = () => fetch(OFC_ANNOUNCEMENTS_URL, { headers: authHeaders() }).then(handleResponse);
+export const createAnnouncement = (data) => fetch(OFC_ANNOUNCEMENTS_URL, {
+  method: 'POST', headers: authHeaders(), body: JSON.stringify(data),
+}).then(handleResponse);
+export const deleteAnnouncement = (id) => fetch(OFC_ANNOUNCEMENT_URL(id), { method: 'DELETE', headers: authHeaders() }).then(handleResponse);
+
+export const exportPlacementData = () => {
+  const token = localStorage.getItem('authToken');
+  return fetch(OFC_EXPORT_URL, { headers: { Authorization: `Token ${token}` } });
+};
+
+export const fetchOfficerStats = (batchId) =>
+  fetch(`${OFC_STATS_URL}${batchId ? `?batch_id=${batchId}` : ''}`, { headers: authHeaders() }).then(handleResponse);
+
+export const fetchOffCampus    = () => fetch(OFC_OFFCAMPUS_URL, { headers: authHeaders() }).then(handleResponse);
+export const addOffCampus      = (data) => fetch(OFC_OFFCAMPUS_URL, {
+  method: 'POST', headers: authHeaders(), body: JSON.stringify(data),
+}).then(handleResponse);
+export const deleteOffCampus   = (id) => fetch(OFC_OFFCAMPUS_ITEM_URL(id), { method: 'DELETE', headers: authHeaders() }).then(handleResponse);
+
+// ── Chairman ──────────────────────────────────────────────────────────────────
+export const fetchChairmanStats    = (batchId) =>
+  fetch(`${CHM_STATS_URL}${batchId ? `?batch_id=${batchId}` : ''}`, { headers: authHeaders() }).then(handleResponse);
+export const fetchChairmanBatches  = () => fetch(CHM_BATCHES_URL,  { headers: authHeaders() }).then(handleResponse);
+export const fetchChairmanStudents = (batchId) => fetch(CHM_STUDENTS_URL(batchId), { headers: authHeaders() }).then(handleResponse);
+export const exportChairmanData    = () => {
+  const token = localStorage.getItem('authToken');
+  return fetch(CHM_EXPORT_URL, { headers: { Authorization: `Token ${token}` } });
+};
+
+// ── Dean ──────────────────────────────────────────────────────────────────────
+export const fetchDeanBatches       = () => fetch(DEAN_BATCHES_URL,       { headers: authHeaders() }).then(handleResponse);
+export const fetchDeanStats         = (batchId) =>
+  fetch(`${DEAN_STATS_URL}${batchId ? `?batch_id=${batchId}` : ''}`, { headers: authHeaders() }).then(handleResponse);
+export const fetchDeanAnnouncements = () => fetch(DEAN_ANNOUNCEMENTS_URL, { headers: authHeaders() }).then(handleResponse);

--- a/src/Modules/PlacementCell/components/AllStudents.jsx
+++ b/src/Modules/PlacementCell/components/AllStudents.jsx
@@ -1,0 +1,232 @@
+import React, { useEffect, useState, useMemo } from 'react';
+import {
+  Stack, Table, Text, Badge, Loader, Alert, Select, ScrollArea,
+  Group, NumberInput, Button, Menu,
+} from '@mantine/core';
+import { notifications } from '@mantine/notifications';
+import jsPDF from 'jspdf';
+import autoTable from 'jspdf-autotable';
+import * as XLSX from 'xlsx';
+import { updateStudentByOfficer } from '../api';
+
+const TH = {
+  padding: '10px 15px',
+  backgroundColor: '#C5E2F6',
+  color: '#3498db',
+  textAlign: 'center',
+  borderRight: '1px solid #d3d3d3',
+  fontWeight: 600,
+  whiteSpace: 'nowrap',
+};
+const TD = { padding: '8px 15px', textAlign: 'center' };
+const rowBg = (i) => ({ backgroundColor: i % 2 !== 0 ? '#E6F7FF' : '#ffffff' });
+
+export default function AllStudents({ fetchBatchesFn, fetchStudentsFn }) {
+  const [batches, setBatches]               = useState([]);
+  const [batchId, setBatchId]               = useState(null);
+  const [batchLabel, setBatchLabel]         = useState('');
+  const [students, setStudents]             = useState([]);
+  const [loadingBatches, setLoadingBatches] = useState(true);
+  const [loadingStudents, setLoadingStudents] = useState(false);
+  const [error, setError]                   = useState(null);
+  const [minCpi, setMinCpi]                 = useState('');
+  const [maxCpi, setMaxCpi]                 = useState('');
+
+  useEffect(() => {
+    fetchBatchesFn()
+      .then((data) => setBatches(data.map((b) => ({ value: String(b.id), label: b.label }))))
+      .catch((e) => setError(e.message))
+      .finally(() => setLoadingBatches(false));
+  }, []);
+
+  useEffect(() => {
+    if (!batchId) { setStudents([]); return; }
+    setLoadingStudents(true);
+    setError(null);
+    setMinCpi('');
+    setMaxCpi('');
+    fetchStudentsFn(batchId)
+      .then(setStudents)
+      .catch((e) => setError(e.message))
+      .finally(() => setLoadingStudents(false));
+  }, [batchId]);
+
+  const filtered = useMemo(() => {
+    return students.filter((s) => {
+      const cpi = parseFloat(s.live_cpi);
+      if (isNaN(cpi)) return true;
+      if (minCpi !== '' && cpi < parseFloat(minCpi)) return false;
+      if (maxCpi !== '' && cpi > parseFloat(maxCpi)) return false;
+      return true;
+    });
+  }, [students, minCpi, maxCpi]);
+
+  const placementLabel = (s) => {
+    const hasOff = s.off_campus?.length > 0;
+    if (s.is_placed && hasOff) return 'Placed';
+    if (s.is_placed) return 'On-Campus';
+    if (hasOff) return 'Off-Campus';
+    return 'Not Placed';
+  };
+
+  const placementColor = (s) =>
+    (s.is_placed || s.off_campus?.length > 0) ? 'green' : 'gray';
+
+  const handleStatusUpdate = async (roll_no, updates) => {
+    try {
+      const result = await updateStudentByOfficer({ roll_no, ...updates });
+      setStudents((prev) => prev.map((s) =>
+        s.roll_no === roll_no ? { ...s, ...result } : s
+      ));
+      notifications.show({ title: 'Updated', message: 'Student status updated.', color: 'green', autoClose: 2000 });
+    } catch (e) {
+      notifications.show({ title: 'Error', message: e.message, color: 'red', autoClose: 4000 });
+    }
+  };
+
+  const tableRows = filtered.map((s, i) => [
+    i + 1, s.roll_no, s.student_name, s.email, s.live_cpi ?? '—',
+    placementLabel(s), s.opted_out ? 'Yes' : 'No',
+  ]);
+
+  const exportPDF = () => {
+    const doc = new jsPDF({ orientation: 'landscape' });
+    doc.setFontSize(14);
+    doc.text(`Student Placement List — ${batchLabel}`, 14, 15);
+    autoTable(doc, {
+      startY: 22,
+      head: [['S.No.', 'Roll No', 'Name', 'Email', 'CPI (Published)', 'Status', 'Opted Out']],
+      body: tableRows,
+      styles: { fontSize: 8 },
+      headStyles: { fillColor: [52, 152, 219] },
+    });
+    doc.save(`students_${batchLabel.replace(/\s+/g, '_')}.pdf`);
+  };
+
+  const exportXLSX = () => {
+    const headers = ['S.No.', 'Roll No', 'Name', 'Email', 'CPI (Published)', 'Status', 'Opted Out'];
+    const ws = XLSX.utils.aoa_to_sheet([headers, ...tableRows]);
+    ws['!cols'] = [{ wch: 6 }, { wch: 12 }, { wch: 24 }, { wch: 28 }, { wch: 14 }, { wch: 14 }, { wch: 10 }];
+    const wb = XLSX.utils.book_new();
+    XLSX.utils.book_append_sheet(wb, ws, 'Students');
+    XLSX.writeFile(wb, `students_${batchLabel.replace(/\s+/g, '_')}.xlsx`);
+  };
+
+  return (
+    <Stack spacing="sm">
+      <Select
+        placeholder="Select batch…"
+        data={batches}
+        value={batchId}
+        onChange={(v) => {
+          setBatchId(v);
+          setBatchLabel(batches.find((b) => b.value === v)?.label ?? '');
+        }}
+        searchable clearable
+        disabled={loadingBatches}
+        nothingFoundMessage="No batches with published results"
+        label="Batch"
+        style={{ maxWidth: 340 }}
+      />
+
+      {error && <Alert color="red">{error}</Alert>}
+
+      {!batchId && !loadingBatches && (
+        <Text color="dimmed" size="sm">Select a batch to view students with published results.</Text>
+      )}
+
+      {loadingStudents && <Loader size="sm" />}
+
+      {batchId && !loadingStudents && (
+        <>
+          <Group align="flex-end" spacing="sm">
+            <NumberInput
+              label="CPI ≥" placeholder="e.g. 7.0" value={minCpi}
+              onChange={(v) => setMinCpi(v === '' ? '' : v)}
+              precision={1} min={0} max={10} step={0.1} style={{ width: 110 }}
+            />
+            <NumberInput
+              label="CPI ≤" placeholder="e.g. 10.0" value={maxCpi}
+              onChange={(v) => setMaxCpi(v === '' ? '' : v)}
+              precision={1} min={0} max={10} step={0.1} style={{ width: 110 }}
+            />
+            {(minCpi !== '' || maxCpi !== '') && (
+              <Button variant="subtle" size="sm" onClick={() => { setMinCpi(''); setMaxCpi(''); }}>
+                Clear Filter
+              </Button>
+            )}
+          </Group>
+
+          <Group position="apart">
+            <Text size="sm" color="dimmed">
+              {filtered.length} student{filtered.length !== 1 ? 's' : ''} with published CPI
+              {(minCpi !== '' || maxCpi !== '') && ` (filtered from ${students.length})`}
+            </Text>
+            {filtered.length > 0 && (
+              <Menu shadow="md" width={160}>
+                <Menu.Target><Button size="xs" variant="light">Export ▾</Button></Menu.Target>
+                <Menu.Dropdown>
+                  <Menu.Item onClick={exportXLSX}>Download XLSX</Menu.Item>
+                  <Menu.Item onClick={exportPDF}>Download PDF</Menu.Item>
+                </Menu.Dropdown>
+              </Menu>
+            )}
+          </Group>
+
+          {filtered.length === 0 ? (
+            <Text color="dimmed" size="sm">No students match the current filter.</Text>
+          ) : (
+            <div style={{ border: '1px solid #d3d3d3', borderRadius: 10, overflow: 'hidden' }}>
+              <ScrollArea>
+                <Table highlightOnHover>
+                  <thead>
+                    <tr>
+                      {['S.No.', 'Roll No', 'Name', 'Email', 'CPI (Published)', 'Status', 'Opted Out', 'Actions'].map((h) => (
+                        <th key={h} style={TH}>{h}</th>
+                      ))}
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {filtered.map((s, i) => (
+                      <tr key={s.roll_no} style={rowBg(i)}>
+                        <td style={TD}>{i + 1}</td>
+                        <td style={TD}>{s.roll_no}</td>
+                        <td style={TD}>{s.student_name}</td>
+                        <td style={TD}>{s.email}</td>
+                        <td style={TD}><strong>{s.live_cpi ?? '—'}</strong></td>
+                        <td style={TD}>
+                          <Badge color={placementColor(s)} variant="light">{placementLabel(s)}</Badge>
+                        </td>
+                        <td style={TD}>{s.opted_out ? 'Yes' : 'No'}</td>
+                        <td style={TD}>
+                          <Menu shadow="sm" width={180}>
+                            <Menu.Target>
+                              <Button size="xs" variant="subtle">Actions ▾</Button>
+                            </Menu.Target>
+                            <Menu.Dropdown>
+                              <Menu.Item
+                                onClick={() => handleStatusUpdate(s.roll_no, { is_placed: !s.is_placed })}
+                              >
+                                {s.is_placed ? 'Mark Not Placed' : 'Mark Placed (On-Campus)'}
+                              </Menu.Item>
+                              <Menu.Item
+                                disabled={s.opted_out}
+                                onClick={() => !s.opted_out && handleStatusUpdate(s.roll_no, { opted_out: true })}
+                              >
+                                {s.opted_out ? 'Already Opted Out' : 'Set Opted Out'}
+                              </Menu.Item>
+                            </Menu.Dropdown>
+                          </Menu>
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </Table>
+              </ScrollArea>
+            </div>
+          )}
+        </>
+      )}
+    </Stack>
+  );
+}

--- a/src/Modules/PlacementCell/components/AnnouncementManager.jsx
+++ b/src/Modules/PlacementCell/components/AnnouncementManager.jsx
@@ -1,0 +1,97 @@
+import React, { useEffect, useState } from 'react';
+import {
+  Stack, Card, Text, Button, TextInput, Textarea, Switch, Group,
+  Modal, Alert, Loader, Badge,
+} from '@mantine/core';
+import { fetchOfficerAnnouncements, createAnnouncement, deleteAnnouncement } from '../api';
+
+export default function AnnouncementManager() {
+  const [items, setItems]     = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError]     = useState(null);
+  const [modal, setModal]     = useState(false);
+  const [form, setForm]       = useState({ title: '', body: '', is_pinned: false });
+  const [saving, setSaving]   = useState(false);
+
+  const reload = () => {
+    setLoading(true);
+    fetchOfficerAnnouncements()
+      .then(setItems)
+      .catch((e) => setError(e.message))
+      .finally(() => setLoading(false));
+  };
+
+  useEffect(reload, []);
+
+  const handleCreate = async () => {
+    setSaving(true);
+    try {
+      await createAnnouncement(form);
+      setModal(false);
+      setForm({ title: '', body: '', is_pinned: false });
+      reload();
+    } catch (e) {
+      alert(e.message);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleDelete = async (id) => {
+    if (!window.confirm('Delete this announcement?')) return;
+    try {
+      await deleteAnnouncement(id);
+      setItems((prev) => prev.filter((a) => a.id !== id));
+    } catch (e) {
+      alert(e.message);
+    }
+  };
+
+  if (loading) return <Loader />;
+  if (error)   return <Alert color="red" title="Error">{error}</Alert>;
+
+  return (
+    <>
+      <Stack spacing="sm">
+        <Group justify="space-between">
+          <Text weight={600} size="lg">Announcements</Text>
+          <Button size="sm" onClick={() => setModal(true)}>+ Post Announcement</Button>
+        </Group>
+        {items.length === 0 && <Text color="dimmed">No announcements yet.</Text>}
+        {items.map((a) => (
+          <Card key={a.id} withBorder radius="md" p="md"
+            style={{ borderLeft: a.is_pinned ? '4px solid #228be6' : '4px solid #dee2e6' }}>
+            <Group justify="space-between" wrap="nowrap">
+              <div>
+                <Group spacing="xs">
+                  <Text weight={700}>{a.title}</Text>
+                  {a.is_pinned && <Badge color="blue" size="xs">Pinned</Badge>}
+                </Group>
+                <Text size="sm" mt={4}>{a.body}</Text>
+                <Text size="xs" color="dimmed" mt={4}>
+                  {a.posted_by_name} · {new Date(a.posted_at).toLocaleDateString()}
+                </Text>
+              </div>
+              <Button size="xs" variant="light" color="red" onClick={() => handleDelete(a.id)}>Delete</Button>
+            </Group>
+          </Card>
+        ))}
+      </Stack>
+
+      <Modal opened={modal} onClose={() => setModal(false)} title="New Announcement">
+        <Stack spacing="sm">
+          <TextInput label="Title" required value={form.title}
+            onChange={(e) => setForm((f) => ({ ...f, title: e.currentTarget.value }))} />
+          <Textarea label="Body" required minRows={3} value={form.body}
+            onChange={(e) => setForm((f) => ({ ...f, body: e.currentTarget.value }))} />
+          <Switch
+            label="Pin this announcement"
+            checked={form.is_pinned}
+            onChange={(e) => { const v = e.currentTarget.checked; setForm((f) => ({ ...f, is_pinned: v })); }}
+          />
+          <Button onClick={handleCreate} loading={saving}>Post</Button>
+        </Stack>
+      </Modal>
+    </>
+  );
+}

--- a/src/Modules/PlacementCell/components/ApplicantList.jsx
+++ b/src/Modules/PlacementCell/components/ApplicantList.jsx
@@ -1,0 +1,137 @@
+import React, { useEffect, useState } from 'react';
+import {
+  Stack, Table, Text, Badge, Button, Group, Select, Checkbox,
+  Alert, Loader, ScrollArea,
+} from '@mantine/core';
+import { fetchApplicants, updateAppStatus, bulkUpdateStatus } from '../api';
+
+const TH = {
+  padding: '10px 15px',
+  backgroundColor: '#C5E2F6',
+  color: '#3498db',
+  textAlign: 'center',
+  borderRight: '1px solid #d3d3d3',
+  fontWeight: 600,
+  whiteSpace: 'nowrap',
+};
+const TD = { padding: '8px 15px', textAlign: 'center' };
+const rowBg = (i) => ({ backgroundColor: i % 2 !== 0 ? '#E6F7FF' : '#ffffff' });
+
+const STATUS_COLOR = {
+  applied: 'yellow', shortlisted: 'blue', placed: 'green', rejected: 'red', withdrawn: 'gray',
+};
+const STATUS_OPTIONS = [
+  { value: 'applied',     label: 'Applied' },
+  { value: 'shortlisted', label: 'Shortlisted' },
+  { value: 'rejected',    label: 'Rejected' },
+  { value: 'placed',      label: 'Placed' },
+  { value: 'withdrawn',   label: 'Withdrawn' },
+];
+
+export default function ApplicantList({ job }) {
+  const [apps, setApps]           = useState([]);
+  const [loading, setLoading]     = useState(true);
+  const [error, setError]         = useState(null);
+  const [selected, setSelected]   = useState([]);
+  const [bulkStatus, setBulkStatus]   = useState('shortlisted');
+  const [bulkLoading, setBulkLoading] = useState(false);
+
+  useEffect(() => {
+    if (!job) return;
+    setLoading(true);
+    fetchApplicants(job.id)
+      .then(setApps)
+      .catch((e) => setError(e.message))
+      .finally(() => setLoading(false));
+  }, [job]);
+
+  const handleStatusChange = async (appId, newStatus) => {
+    try {
+      const updated = await updateAppStatus(appId, newStatus);
+      setApps((prev) => prev.map((a) => a.id === appId ? { ...a, status: updated.status } : a));
+    } catch (e) {
+      alert(e.message);
+    }
+  };
+
+  const handleBulk = async () => {
+    if (selected.length === 0) return;
+    setBulkLoading(true);
+    try {
+      await bulkUpdateStatus(selected, bulkStatus);
+      setApps((prev) => prev.map((a) => selected.includes(a.id) ? { ...a, status: bulkStatus } : a));
+      setSelected([]);
+    } catch (e) {
+      alert(e.message);
+    } finally {
+      setBulkLoading(false);
+    }
+  };
+
+  const toggleSelect = (id) => setSelected((prev) =>
+    prev.includes(id) ? prev.filter((x) => x !== id) : [...prev, id]
+  );
+  const toggleAll = () =>
+    setSelected(selected.length === apps.length ? [] : apps.map((a) => a.id));
+
+  if (!job)    return <Text color="dimmed">Select a job post to view applicants.</Text>;
+  if (loading) return <Loader />;
+  if (error)   return <Alert color="red" title="Error">{error}</Alert>;
+
+  return (
+    <Stack spacing="sm">
+      <Text weight={600}>{job.company_name} — {job.role} ({apps.length} applicant{apps.length !== 1 ? 's' : ''})</Text>
+
+      {selected.length > 0 && (
+        <Group>
+          <Text size="sm">{selected.length} selected</Text>
+          <Select size="sm" data={STATUS_OPTIONS} value={bulkStatus} onChange={setBulkStatus} style={{ width: 160 }} />
+          <Button size="sm" loading={bulkLoading} onClick={handleBulk}>Update Selected</Button>
+        </Group>
+      )}
+
+      <div style={{ border: '1px solid #d3d3d3', borderRadius: 10, overflow: 'hidden' }}>
+        <ScrollArea>
+          <Table highlightOnHover>
+            <thead>
+              <tr>
+                <th style={TH}>
+                  <Checkbox
+                    checked={selected.length === apps.length && apps.length > 0}
+                    onChange={toggleAll}
+                  />
+                </th>
+                {['Roll No', 'Name', 'Email', 'CPI', 'Status', 'Applied'].map((h) => (
+                  <th key={h} style={TH}>{h}</th>
+                ))}
+              </tr>
+            </thead>
+            <tbody>
+              {apps.map((a, i) => (
+                <tr key={a.id} style={rowBg(i)}>
+                  <td style={TD}>
+                    <Checkbox checked={selected.includes(a.id)} onChange={() => toggleSelect(a.id)} />
+                  </td>
+                  <td style={TD}>{a.roll_no}</td>
+                  <td style={TD}>{a.student_name}</td>
+                  <td style={TD}>{a.email}</td>
+                  <td style={TD}><strong>{a.live_cpi ?? '—'}</strong></td>
+                  <td style={TD}>
+                    <Select
+                      size="xs"
+                      data={STATUS_OPTIONS}
+                      value={a.status}
+                      onChange={(v) => handleStatusChange(a.id, v)}
+                      style={{ width: 130 }}
+                    />
+                  </td>
+                  <td style={TD}>{new Date(a.applied_at).toLocaleDateString()}</td>
+                </tr>
+              ))}
+            </tbody>
+          </Table>
+        </ScrollArea>
+      </div>
+    </Stack>
+  );
+}

--- a/src/Modules/PlacementCell/components/CompanyManager.jsx
+++ b/src/Modules/PlacementCell/components/CompanyManager.jsx
@@ -1,0 +1,133 @@
+import React, { useEffect, useState } from 'react';
+import {
+  Stack, Table, Text, Button, TextInput, Textarea, Modal,
+  Group, Alert, Loader, ScrollArea,
+} from '@mantine/core';
+import { fetchCompanies, createCompany, updateCompany, deleteCompany } from '../api';
+
+const TH = {
+  padding: '10px 15px',
+  backgroundColor: '#C5E2F6',
+  color: '#3498db',
+  textAlign: 'center',
+  borderRight: '1px solid #d3d3d3',
+  fontWeight: 600,
+  whiteSpace: 'nowrap',
+};
+const TD = { padding: '8px 15px', textAlign: 'center' };
+const rowBg = (i) => ({ backgroundColor: i % 2 !== 0 ? '#E6F7FF' : '#ffffff' });
+
+const EMPTY = { name: '', sector: '', website: '', description: '' };
+
+export default function CompanyManager() {
+  const [companies, setCompanies] = useState([]);
+  const [loading, setLoading]     = useState(true);
+  const [error, setError]         = useState(null);
+  const [modal, setModal]         = useState(false);
+  const [editing, setEditing]     = useState(null);
+  const [form, setForm]           = useState(EMPTY);
+  const [saving, setSaving]       = useState(false);
+
+  const reload = () => {
+    setLoading(true);
+    fetchCompanies()
+      .then(setCompanies)
+      .catch((e) => setError(e.message))
+      .finally(() => setLoading(false));
+  };
+
+  useEffect(reload, []);
+
+  const openCreate = () => { setEditing(null); setForm(EMPTY); setModal(true); };
+  const openEdit   = (c) => {
+    setEditing(c);
+    setForm({ name: c.name, sector: c.sector, website: c.website, description: c.description });
+    setModal(true);
+  };
+
+  const handleSave = async () => {
+    setSaving(true);
+    try {
+      if (editing) await updateCompany(editing.id, form);
+      else         await createCompany(form);
+      setModal(false);
+      reload();
+    } catch (e) {
+      alert(e.message);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleDelete = async (id) => {
+    if (!window.confirm('Delete this company?')) return;
+    try {
+      await deleteCompany(id);
+      reload();
+    } catch (e) {
+      alert(e.message);
+    }
+  };
+
+  if (loading) return <Loader />;
+  if (error)   return <Alert color="red" title="Error">{error}</Alert>;
+
+  return (
+    <>
+      <Stack spacing="sm">
+        <Group justify="space-between">
+          <Text weight={600} size="lg">Companies</Text>
+          <Button size="sm" onClick={openCreate}>+ Add Company</Button>
+        </Group>
+
+        <div style={{ border: '1px solid #d3d3d3', borderRadius: 10, overflow: 'hidden' }}>
+          <ScrollArea>
+            <Table highlightOnHover>
+              <thead>
+                <tr>
+                  {['S.No.', 'Name', 'Sector', 'Website', 'Actions'].map((h) => (
+                    <th key={h} style={TH}>{h}</th>
+                  ))}
+                </tr>
+              </thead>
+              <tbody>
+                {companies.map((c, i) => (
+                  <tr key={c.id} style={rowBg(i)}>
+                    <td style={TD}>{i + 1}</td>
+                    <td style={TD}>{c.name}</td>
+                    <td style={TD}>{c.sector || '—'}</td>
+                    <td style={TD}>
+                      {c.website
+                        ? <a href={c.website} target="_blank" rel="noreferrer" style={{ color: '#3498db' }}>{c.website}</a>
+                        : '—'}
+                    </td>
+                    <td style={TD}>
+                      <Group spacing="xs" justify="center">
+                        <Button size="xs" variant="light" onClick={() => openEdit(c)}>Edit</Button>
+                        <Button size="xs" variant="light" color="red" onClick={() => handleDelete(c.id)}>Delete</Button>
+                      </Group>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </Table>
+          </ScrollArea>
+        </div>
+      </Stack>
+
+      <Modal opened={modal} onClose={() => setModal(false)} title={editing ? 'Edit Company' : 'Add Company'}>
+        <Stack spacing="sm">
+          <TextInput label="Company Name" required value={form.name}
+            onChange={(e) => setForm((f) => ({ ...f, name: e.currentTarget.value }))} />
+          <TextInput label="Sector" value={form.sector}
+            onChange={(e) => setForm((f) => ({ ...f, sector: e.currentTarget.value }))} />
+          <TextInput label="Website" value={form.website}
+            onChange={(e) => setForm((f) => ({ ...f, website: e.currentTarget.value }))} />
+          <Textarea label="Description" value={form.description}
+            onChange={(e) => setForm((f) => ({ ...f, description: e.currentTarget.value }))} />
+          <Button onClick={handleSave} loading={saving}>{editing ? 'Update' : 'Create'}</Button>
+        </Stack>
+      </Modal>
+    </>
+  );
+}

--- a/src/Modules/PlacementCell/components/ExportPanel.jsx
+++ b/src/Modules/PlacementCell/components/ExportPanel.jsx
@@ -1,0 +1,36 @@
+import React, { useState } from 'react';
+import { Button, Stack, Text, Alert } from '@mantine/core';
+
+export default function ExportPanel({ exportFn, label = 'Export as Excel' }) {
+  const [loading, setLoading] = useState(false);
+  const [error, setError]     = useState(null);
+
+  const handleExport = async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await exportFn();
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      const blob = await res.blob();
+      const url  = URL.createObjectURL(blob);
+      const a    = document.createElement('a');
+      a.href     = url;
+      a.download = 'placement_data.xlsx';
+      a.click();
+      URL.revokeObjectURL(url);
+    } catch (e) {
+      setError(e.message);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <Stack spacing="sm" style={{ maxWidth: 300 }}>
+      <Text weight={600}>Export Placement Data</Text>
+      <Text size="sm" color="dimmed">Download all placement applications and results as an Excel file.</Text>
+      {error && <Alert color="red">{error}</Alert>}
+      <Button onClick={handleExport} loading={loading}>{label}</Button>
+    </Stack>
+  );
+}

--- a/src/Modules/PlacementCell/components/JobCard.jsx
+++ b/src/Modules/PlacementCell/components/JobCard.jsx
@@ -1,0 +1,132 @@
+import React, { useState } from 'react';
+import { Card, Text, Badge, Group, Button, Stack } from '@mantine/core';
+import { notifications } from '@mantine/notifications';
+import { applyToJob } from '../api';
+
+const TYPE_LABEL = { placement: 'Placement', internship: 'Internship', ppo: 'PPO' };
+const TYPE_COLOR  = { placement: 'blue', internship: 'grape', ppo: 'teal' };
+
+function deadlineBadgeColor(daysLeft) {
+  if (daysLeft <= 1) return 'red';
+  if (daysLeft <= 7) return 'orange';
+  return 'green';
+}
+
+export default function JobCard({ job, onApplied, showApply = true }) {
+  const [loading, setLoading]   = useState(false);
+  const [applied, setApplied]   = useState(false);
+  const [linkLoading, setLinkLoading] = useState(false);
+
+  const handleApply = async () => {
+    setLoading(true);
+    try {
+      await applyToJob(job.id);
+      setApplied(true);
+      if (onApplied) onApplied(job.id);
+      notifications.show({
+        title: 'Application Submitted',
+        message: `Applied to ${job.role} at ${job.company_name}`,
+        color: 'green',
+        autoClose: 3000,
+      });
+    } catch (e) {
+      notifications.show({
+        title: 'Cannot Apply',
+        message: e.message,
+        color: 'red',
+        autoClose: 5000,
+      });
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleApplyViaLink = async () => {
+    setLinkLoading(true);
+    try {
+      await applyToJob(job.id);
+      setApplied(true);
+      if (onApplied) onApplied(job.id);
+      notifications.show({
+        title: 'Application Tracked',
+        message: 'Your application has been recorded. Opening the company portal…',
+        color: 'blue',
+        autoClose: 3000,
+      });
+    } catch (e) {
+      // If already applied, that's fine — still open the link
+      if (!e.message?.toLowerCase().includes('already applied')) {
+        notifications.show({ title: 'Note', message: e.message, color: 'yellow', autoClose: 4000 });
+      } else {
+        setApplied(true);
+      }
+    } finally {
+      setLinkLoading(false);
+      window.open(job.apply_link, '_blank', 'noopener,noreferrer');
+    }
+  };
+
+  return (
+    <Card withBorder radius="md" p="md" shadow="xs">
+      <Stack spacing={6}>
+        <Group justify="space-between" wrap="nowrap">
+          <Text weight={700} size="md" lineClamp={1}>{job.company_name}</Text>
+          <Badge color={TYPE_COLOR[job.job_type] || 'blue'} variant="light">
+            {TYPE_LABEL[job.job_type] || job.job_type}
+          </Badge>
+        </Group>
+        <Text size="sm" weight={500}>{job.role}</Text>
+        {job.location && <Text size="xs" color="dimmed">{job.location}</Text>}
+        <Group spacing="xs">
+          {job.ctc != null && (
+            <Badge color="teal" variant="outline" size="sm">CTC: {job.ctc} LPA</Badge>
+          )}
+          {job.stipend != null && (
+            <Badge color="teal" variant="outline" size="sm">Stipend: ₹{job.stipend}/mo</Badge>
+          )}
+          {parseFloat(job.min_cpi) > 0 && (
+            <Badge color="gray" variant="outline" size="sm">Min CPI: {job.min_cpi}</Badge>
+          )}
+        </Group>
+        {job.eligible_batches?.length > 0 && (
+          <Text size="xs" color="dimmed">Batches: {job.eligible_batches.join(', ')}</Text>
+        )}
+        <Group position="apart" align="center">
+          <Badge color={deadlineBadgeColor(job.days_left)} variant="dot" size="sm">
+            {job.days_left === 0 ? 'Deadline today' : `${job.days_left}d left`}
+          </Badge>
+          {showApply && (
+            <Group spacing="xs">
+              {/* Normal apply button — shown only if no external-only link or if we want both */}
+              {!job.apply_link && (
+                <Button
+                  size="xs"
+                  variant={applied ? 'outline' : 'filled'}
+                  color={applied ? 'green' : 'blue'}
+                  loading={loading}
+                  disabled={applied}
+                  onClick={handleApply}
+                >
+                  {applied ? 'Applied ✓' : 'Apply'}
+                </Button>
+              )}
+              {/* External apply link — tracks application AND opens external portal */}
+              {job.apply_link && (
+                <Button
+                  size="xs"
+                  variant={applied ? 'outline' : 'filled'}
+                  color={applied ? 'green' : 'blue'}
+                  loading={linkLoading}
+                  disabled={applied}
+                  onClick={handleApplyViaLink}
+                >
+                  {applied ? 'Applied ✓' : 'Apply via Link ↗'}
+                </Button>
+              )}
+            </Group>
+          )}
+        </Group>
+      </Stack>
+    </Card>
+  );
+}

--- a/src/Modules/PlacementCell/components/JobList.jsx
+++ b/src/Modules/PlacementCell/components/JobList.jsx
@@ -1,0 +1,47 @@
+import React, { useEffect, useState } from 'react';
+import { Stack, Text, Loader, Alert, TextInput, SimpleGrid } from '@mantine/core';
+import { fetchActiveJobs } from '../api';
+import JobCard from './JobCard';
+
+export default function JobList() {
+  const [jobs, setJobs]   = useState([]);
+  const [query, setQuery] = useState('');
+  const [loading, setLoading] = useState(true);
+  const [error, setError]     = useState(null);
+
+  useEffect(() => {
+    fetchActiveJobs()
+      .then(setJobs)
+      .catch((e) => setError(e.message))
+      .finally(() => setLoading(false));
+  }, []);
+
+  const filtered = jobs.filter((j) => {
+    const q = query.toLowerCase();
+    return (
+      j.company_name.toLowerCase().includes(q) ||
+      j.role.toLowerCase().includes(q) ||
+      j.job_type.toLowerCase().includes(q)
+    );
+  });
+
+  if (loading) return <Loader />;
+  if (error)   return <Alert color="red" title="Error">{error}</Alert>;
+
+  return (
+    <Stack spacing="md">
+      <TextInput
+        placeholder="Search by company, role…"
+        value={query}
+        onChange={(e) => setQuery(e.currentTarget.value)}
+      />
+      {filtered.length === 0 ? (
+        <Text color="dimmed">No job openings match your search.</Text>
+      ) : (
+        <SimpleGrid cols={2} spacing="md" breakpoints={[{ maxWidth: 768, cols: 1 }]}>
+          {filtered.map((job) => <JobCard key={job.id} job={job} />)}
+        </SimpleGrid>
+      )}
+    </Stack>
+  );
+}

--- a/src/Modules/PlacementCell/components/JobPostManager.jsx
+++ b/src/Modules/PlacementCell/components/JobPostManager.jsx
@@ -1,0 +1,261 @@
+import React, { useEffect, useState } from 'react';
+import {
+  Stack, Table, Text, Button, TextInput, Textarea, Modal, Group,
+  Alert, Loader, Select, MultiSelect, NumberInput, Badge, ScrollArea,
+} from '@mantine/core';
+import { fetchAllJobs, createJobPost, updateJobPost, toggleJobPost, fetchCompanies, fetchBatches } from '../api';
+import ApplicantList from './ApplicantList';
+
+const TH = {
+  padding: '10px 15px',
+  backgroundColor: '#C5E2F6',
+  color: '#3498db',
+  textAlign: 'center',
+  borderRight: '1px solid #d3d3d3',
+  fontWeight: 600,
+  whiteSpace: 'nowrap',
+};
+const TD = { padding: '8px 15px', textAlign: 'center' };
+const rowBg = (i) => ({ backgroundColor: i % 2 !== 0 ? '#E6F7FF' : '#ffffff' });
+
+const TYPE_OPTIONS = [
+  { value: 'placement',  label: 'Placement' },
+  { value: 'internship', label: 'Internship' },
+  { value: 'ppo',        label: 'Pre Placement Offer' },
+];
+const TYPE_COLOR = { placement: 'blue', internship: 'grape', ppo: 'teal' };
+
+const EMPTY = {
+  company: '', role: '', job_type: 'placement', description: '',
+  ctc: '', stipend: '', location: '', min_cpi: 0,
+  deadline: '', eligible_batches: [], eligible_programmes: [], eligible_disciplines: [],
+  apply_link: '',
+};
+
+export default function JobPostManager() {
+  const [jobs, setJobs]           = useState([]);
+  const [companies, setCompanies] = useState([]);
+  const [batches, setBatches]     = useState([]);
+  const [loading, setLoading]     = useState(true);
+  const [error, setError]         = useState(null);
+  const [modal, setModal]         = useState(false);
+  const [editing, setEditing]     = useState(null);
+  const [form, setForm]           = useState(EMPTY);
+  const [saving, setSaving]       = useState(false);
+  const [appJob, setAppJob]       = useState(null);
+  const [appModal, setAppModal]   = useState(false);
+
+  const reload = () => {
+    Promise.all([fetchAllJobs(), fetchCompanies(), fetchBatches()])
+      .then(([j, c, b]) => {
+        setJobs(j);
+        setCompanies(c);
+        setBatches(b.map((bt) => ({ value: bt.label, label: bt.label })));
+      })
+      .catch((e) => setError(e.message))
+      .finally(() => setLoading(false));
+  };
+
+  useEffect(reload, []);
+
+  const companyOptions = companies.map((c) => ({ value: String(c.id), label: c.name }));
+
+  const openCreate = () => { setEditing(null); setForm(EMPTY); setModal(true); };
+  const openEdit   = (j) => {
+    setEditing(j);
+    setForm({
+      company:              String(j.company?.id || j.company_id || ''),
+      role:                 j.role,
+      job_type:             j.job_type,
+      description:          j.description || '',
+      ctc:                  j.ctc || '',
+      stipend:              j.stipend || '',
+      location:             j.location || '',
+      min_cpi:              parseFloat(j.min_cpi) || 0,
+      deadline:             j.deadline ? j.deadline.slice(0, 16) : '',
+      eligible_batches:     j.eligible_batches || [],
+      eligible_programmes:  j.eligible_programmes || [],
+      eligible_disciplines: j.eligible_disciplines || [],
+      apply_link:           j.apply_link || '',
+    });
+    setModal(true);
+  };
+
+  const openApplicants = (j) => { setAppJob(j); setAppModal(true); };
+
+  const handleSave = async () => {
+    setSaving(true);
+    try {
+      const toDecimal = (v) => (v === '' || v === null || v === undefined) ? null : v;
+      const payload = {
+        ...form,
+        company: parseInt(form.company, 10),
+        ctc:     toDecimal(form.ctc),
+        stipend: toDecimal(form.stipend),
+        min_cpi: form.min_cpi ?? 0,
+      };
+      if (editing) await updateJobPost(editing.id, payload);
+      else         await createJobPost(payload);
+      setModal(false);
+      reload();
+    } catch (e) {
+      alert(e.message);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleToggle = async (id) => {
+    try {
+      const updated = await toggleJobPost(id);
+      setJobs((prev) => prev.map((j) => j.id === id ? { ...j, is_active: updated.is_active } : j));
+    } catch (e) {
+      alert(e.message);
+    }
+  };
+
+  if (loading) return <Loader />;
+  if (error)   return <Alert color="red" title="Error">{error}</Alert>;
+
+  return (
+    <>
+      <Stack spacing="sm">
+        <Group justify="space-between">
+          <Text weight={600} size="lg">Job Posts</Text>
+          <Button size="sm" onClick={openCreate}>+ Create Job Post</Button>
+        </Group>
+
+        <div style={{ border: '1px solid #d3d3d3', borderRadius: 10, overflow: 'hidden' }}>
+          <ScrollArea>
+            <Table highlightOnHover>
+              <thead>
+                <tr>
+                  {['Company', 'Role', 'Type', 'Eligible Batches', 'CTC / Stipend', 'Min CPI', 'Deadline', 'Status', 'Actions'].map((h) => (
+                    <th key={h} style={TH}>{h}</th>
+                  ))}
+                </tr>
+              </thead>
+              <tbody>
+                {jobs.map((j, i) => (
+                  <tr key={j.id} style={rowBg(i)}>
+                    <td style={TD}>{j.company_name || j.company?.name}</td>
+                    <td style={TD}>{j.role}</td>
+                    <td style={TD}>
+                      <Badge color={TYPE_COLOR[j.job_type] || 'blue'} variant="light">
+                        {TYPE_OPTIONS.find((t) => t.value === j.job_type)?.label || j.job_type}
+                      </Badge>
+                    </td>
+                    <td style={TD}>
+                      {j.eligible_batches?.length
+                        ? j.eligible_batches.slice(0, 2).join(', ') + (j.eligible_batches.length > 2 ? ` +${j.eligible_batches.length - 2}` : '')
+                        : <Text size="xs" color="dimmed">All</Text>}
+                    </td>
+                    <td style={TD}>{j.ctc ? `${j.ctc} LPA` : j.stipend ? `₹${j.stipend}/mo` : '—'}</td>
+                    <td style={TD}>{parseFloat(j.min_cpi) > 0 ? j.min_cpi : '—'}</td>
+                    <td style={TD}>{new Date(j.deadline).toLocaleDateString()}</td>
+                    <td style={TD}>
+                      <Badge color={j.is_active ? 'green' : 'gray'}>{j.is_active ? 'Active' : 'Inactive'}</Badge>
+                    </td>
+                    <td style={TD}>
+                      <Group gap="xs" wrap="nowrap" justify="center">
+                        <Button size="xs" variant="light" onClick={() => openEdit(j)}>Edit</Button>
+                        <Button size="xs" variant="light" color={j.is_active ? 'orange' : 'green'} onClick={() => handleToggle(j.id)}>
+                          {j.is_active ? 'Deactivate' : 'Activate'}
+                        </Button>
+                        <Button size="xs" variant="outline" onClick={() => openApplicants(j)}>Applicants</Button>
+                      </Group>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </Table>
+          </ScrollArea>
+        </div>
+      </Stack>
+
+      {/* Create / Edit modal */}
+      <Modal opened={modal} onClose={() => setModal(false)} title={editing ? 'Edit Job Post' : 'Create Job Post'} size="lg">
+        <Stack spacing="sm">
+          <Select
+            label="Company" required
+            data={companyOptions}
+            value={form.company}
+            onChange={(v) => setForm((f) => ({ ...f, company: v }))}
+            searchable
+          />
+          <TextInput
+            label="Role" required
+            value={form.role}
+            onChange={(e) => setForm((f) => ({ ...f, role: e.currentTarget.value }))}
+          />
+          <Select
+            label="Type"
+            data={TYPE_OPTIONS}
+            value={form.job_type}
+            onChange={(v) => setForm((f) => ({ ...f, job_type: v }))}
+          />
+          <Textarea
+            label="Description"
+            value={form.description}
+            onChange={(e) => setForm((f) => ({ ...f, description: e.currentTarget.value }))}
+          />
+          <Group grow>
+            <TextInput
+              label="CTC (LPA) — optional" placeholder="e.g. 12.5"
+              value={form.ctc}
+              onChange={(e) => setForm((f) => ({ ...f, ctc: e.currentTarget.value }))}
+            />
+            <TextInput
+              label="Stipend (₹/mo) — optional" placeholder="e.g. 25000"
+              value={form.stipend}
+              onChange={(e) => setForm((f) => ({ ...f, stipend: e.currentTarget.value }))}
+            />
+          </Group>
+          <TextInput
+            label="Location"
+            value={form.location}
+            onChange={(e) => setForm((f) => ({ ...f, location: e.currentTarget.value }))}
+          />
+          <NumberInput
+            label="Minimum CPI"
+            value={form.min_cpi}
+            onChange={(v) => setForm((f) => ({ ...f, min_cpi: v }))}
+            precision={1} min={0} max={10} step={0.1}
+          />
+          <MultiSelect
+            label="Eligible Batches"
+            placeholder="All batches if empty"
+            data={batches}
+            value={form.eligible_batches}
+            onChange={(v) => setForm((f) => ({ ...f, eligible_batches: v }))}
+            searchable clearable
+          />
+          <TextInput
+            label="External Apply Link — optional"
+            placeholder="https://company.com/careers/..."
+            description="If students apply via an external portal, paste the link here. Clicking it will still track their application."
+            value={form.apply_link}
+            onChange={(e) => setForm((f) => ({ ...f, apply_link: e.currentTarget.value }))}
+          />
+          <TextInput
+            label="Deadline (date & time)"
+            type="datetime-local"
+            value={form.deadline}
+            onChange={(e) => setForm((f) => ({ ...f, deadline: e.currentTarget.value }))}
+          />
+          <Button onClick={handleSave} loading={saving}>{editing ? 'Update' : 'Create'}</Button>
+        </Stack>
+      </Modal>
+
+      {/* Applicants modal */}
+      <Modal
+        opened={appModal}
+        onClose={() => setAppModal(false)}
+        title={appJob ? `Applicants — ${appJob.company_name || appJob.company?.name} · ${appJob.role}` : 'Applicants'}
+        size="90%"
+      >
+        {appJob && <ApplicantList job={appJob} />}
+      </Modal>
+    </>
+  );
+}

--- a/src/Modules/PlacementCell/components/MyApplications.jsx
+++ b/src/Modules/PlacementCell/components/MyApplications.jsx
@@ -1,0 +1,57 @@
+import React, { useEffect, useState } from 'react';
+import { Stack, Text, Badge, Card, Group, Button, Loader, Alert } from '@mantine/core';
+import { fetchApplications, withdrawApplication } from '../api';
+
+const STATUS_COLOR = {
+  applied: 'yellow', shortlisted: 'blue', placed: 'green', rejected: 'red', withdrawn: 'gray',
+};
+
+export default function MyApplications() {
+  const [apps, setApps]       = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError]     = useState(null);
+
+  useEffect(() => {
+    fetchApplications()
+      .then(setApps)
+      .catch((e) => setError(e.message))
+      .finally(() => setLoading(false));
+  }, []);
+
+  const handleWithdraw = async (id) => {
+    try {
+      await withdrawApplication(id);
+      setApps((prev) => prev.map((a) => a.id === id ? { ...a, status: 'withdrawn' } : a));
+    } catch (e) {
+      alert(e.message);
+    }
+  };
+
+  if (loading) return <Loader />;
+  if (error)   return <Alert color="red" title="Error">{error}</Alert>;
+  if (apps.length === 0) return <Text color="dimmed">You have not applied to any positions yet.</Text>;
+
+  return (
+    <Stack spacing="sm">
+      {apps.map((app) => (
+        <Card key={app.id} withBorder radius="md" p="md">
+          <Group justify="space-between" wrap="nowrap">
+            <div>
+              <Text weight={700}>{app.company_name}</Text>
+              <Text size="sm">{app.role}</Text>
+              <Text size="xs" color="dimmed">Applied: {new Date(app.applied_at).toLocaleDateString()}</Text>
+            </div>
+            <Group spacing="xs">
+              <Badge color={STATUS_COLOR[app.status] || 'gray'}>{app.status}</Badge>
+              {app.status === 'applied' && (
+                <Button size="xs" variant="light" color="red" onClick={() => handleWithdraw(app.id)}>
+                  Withdraw
+                </Button>
+              )}
+            </Group>
+          </Group>
+        </Card>
+      ))}
+    </Stack>
+  );
+}

--- a/src/Modules/PlacementCell/components/OffCampusManager.jsx
+++ b/src/Modules/PlacementCell/components/OffCampusManager.jsx
@@ -1,0 +1,184 @@
+import React, { useEffect, useState } from 'react';
+import {
+  Stack, Table, Text, Button, TextInput, Textarea, Modal, Group,
+  Alert, Loader, Select, Badge, ScrollArea,
+} from '@mantine/core';
+import { notifications } from '@mantine/notifications';
+import { fetchOffCampus, addOffCampus, deleteOffCampus } from '../api';
+
+const TH = {
+  padding: '10px 15px',
+  backgroundColor: '#C5E2F6',
+  color: '#3498db',
+  textAlign: 'center',
+  borderRight: '1px solid #d3d3d3',
+  fontWeight: 600,
+  whiteSpace: 'nowrap',
+};
+const TD = { padding: '8px 15px', textAlign: 'center' };
+const rowBg = (i) => ({ backgroundColor: i % 2 !== 0 ? '#E6F7FF' : '#ffffff' });
+
+const TYPE_OPTIONS = [
+  { value: 'placement',  label: 'Placement' },
+  { value: 'internship', label: 'Internship' },
+];
+
+const EMPTY = {
+  roll_no: '', company_name: '', role: '', offer_type: 'placement',
+  ctc: '', stipend: '', offer_date: '', notes: '',
+};
+
+export default function OffCampusManager() {
+  const [records, setRecords]   = useState([]);
+  const [loading, setLoading]   = useState(true);
+  const [error, setError]       = useState(null);
+  const [modal, setModal]       = useState(false);
+  const [form, setForm]         = useState(EMPTY);
+  const [saving, setSaving]     = useState(false);
+
+  const reload = () => {
+    setLoading(true);
+    fetchOffCampus()
+      .then(setRecords)
+      .catch((e) => setError(e.message))
+      .finally(() => setLoading(false));
+  };
+
+  useEffect(reload, []);
+
+  const handleAdd = async () => {
+    if (!form.roll_no.trim() || !form.company_name.trim() || !form.role.trim() || !form.offer_date) {
+      notifications.show({ title: 'Validation', message: 'Roll No, Company, Role and Offer Date are required.', color: 'red' });
+      return;
+    }
+    setSaving(true);
+    try {
+      const toDecimal = (v) => (v === '' || v === null || v === undefined) ? null : v;
+      await addOffCampus({
+        ...form,
+        ctc:     toDecimal(form.ctc),
+        stipend: toDecimal(form.stipend),
+      });
+      setModal(false);
+      setForm(EMPTY);
+      reload();
+      notifications.show({ title: 'Added', message: 'Off-campus placement recorded.', color: 'green', autoClose: 3000 });
+    } catch (e) {
+      notifications.show({ title: 'Error', message: e.message, color: 'red', autoClose: 5000 });
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleDelete = async (id) => {
+    if (!window.confirm('Remove this off-campus placement record?')) return;
+    try {
+      await deleteOffCampus(id);
+      setRecords((prev) => prev.filter((r) => r.id !== id));
+      notifications.show({ title: 'Deleted', message: 'Record removed.', color: 'orange', autoClose: 3000 });
+    } catch (e) {
+      notifications.show({ title: 'Error', message: e.message, color: 'red', autoClose: 5000 });
+    }
+  };
+
+  if (loading) return <Loader />;
+  if (error)   return <Alert color="red" title="Error">{error}</Alert>;
+
+  return (
+    <>
+      <Stack spacing="sm">
+        <Group justify="space-between">
+          <Text weight={600} size="lg">Off-Campus Placements</Text>
+          <Button size="sm" onClick={() => { setForm(EMPTY); setModal(true); }}>+ Add Record</Button>
+        </Group>
+
+        {records.length === 0 ? (
+          <Text color="dimmed" size="sm">No off-campus placement records yet.</Text>
+        ) : (
+          <div style={{ border: '1px solid #d3d3d3', borderRadius: 10, overflow: 'hidden' }}>
+            <ScrollArea>
+              <Table highlightOnHover>
+                <thead>
+                  <tr>
+                    {['S.No.', 'Roll No', 'Name', 'Company', 'Role', 'Type', 'CTC / Stipend', 'Offer Date', 'Notes', 'Action'].map((h) => (
+                      <th key={h} style={TH}>{h}</th>
+                    ))}
+                  </tr>
+                </thead>
+                <tbody>
+                  {records.map((r, i) => (
+                    <tr key={r.id} style={rowBg(i)}>
+                      <td style={TD}>{i + 1}</td>
+                      <td style={TD}>{r.roll_no}</td>
+                      <td style={TD}>{r.student_name}</td>
+                      <td style={TD}>{r.company_name}</td>
+                      <td style={TD}>{r.role}</td>
+                      <td style={TD}>
+                        <Badge color={r.offer_type === 'placement' ? 'blue' : 'grape'} variant="light">
+                          {r.offer_type === 'placement' ? 'Placement' : 'Internship'}
+                        </Badge>
+                      </td>
+                      <td style={TD}>
+                        {r.ctc ? `${r.ctc} LPA` : r.stipend ? `₹${r.stipend}/mo` : '—'}
+                      </td>
+                      <td style={TD}>{r.offer_date}</td>
+                      <td style={TD}><Text size="xs" lineClamp={2}>{r.notes || '—'}</Text></td>
+                      <td style={TD}>
+                        <Button size="xs" color="red" variant="light" onClick={() => handleDelete(r.id)}>
+                          Delete
+                        </Button>
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </Table>
+            </ScrollArea>
+          </div>
+        )}
+      </Stack>
+
+      <Modal opened={modal} onClose={() => setModal(false)} title="Add Off-Campus Placement" size="md">
+        <Stack spacing="sm">
+          <TextInput
+            label="Student Roll No" required placeholder="e.g. 21BCS001"
+            value={form.roll_no}
+            onChange={(e) => setForm((f) => ({ ...f, roll_no: e.currentTarget.value }))}
+          />
+          <TextInput
+            label="Company Name" required value={form.company_name}
+            onChange={(e) => setForm((f) => ({ ...f, company_name: e.currentTarget.value }))}
+          />
+          <TextInput
+            label="Role" required value={form.role}
+            onChange={(e) => setForm((f) => ({ ...f, role: e.currentTarget.value }))}
+          />
+          <Select
+            label="Offer Type"
+            data={TYPE_OPTIONS}
+            value={form.offer_type}
+            onChange={(v) => setForm((f) => ({ ...f, offer_type: v }))}
+          />
+          <Group grow>
+            <TextInput
+              label="CTC (LPA) — optional" placeholder="e.g. 12.5" value={form.ctc}
+              onChange={(e) => setForm((f) => ({ ...f, ctc: e.currentTarget.value }))}
+            />
+            <TextInput
+              label="Stipend (₹/mo) — optional" placeholder="e.g. 25000" value={form.stipend}
+              onChange={(e) => setForm((f) => ({ ...f, stipend: e.currentTarget.value }))}
+            />
+          </Group>
+          <TextInput
+            label="Offer Date" required type="date" value={form.offer_date}
+            onChange={(e) => setForm((f) => ({ ...f, offer_date: e.currentTarget.value }))}
+          />
+          <Textarea
+            label="Notes" value={form.notes}
+            onChange={(e) => setForm((f) => ({ ...f, notes: e.currentTarget.value }))}
+          />
+          <Button onClick={handleAdd} loading={saving}>Add Record</Button>
+        </Stack>
+      </Modal>
+    </>
+  );
+}

--- a/src/Modules/PlacementCell/components/PlacementStatistics.jsx
+++ b/src/Modules/PlacementCell/components/PlacementStatistics.jsx
@@ -1,0 +1,100 @@
+import React, { useEffect, useState } from 'react';
+import {
+  Stack, Text, Card, SimpleGrid, Group, Loader, Alert, RingProgress,
+  Center, Select, Badge,
+} from '@mantine/core';
+
+export default function PlacementStatistics({ fetchFn, fetchBatchesFn }) {
+  const [batches, setBatches]         = useState([]);
+  const [batchId, setBatchId]         = useState(null);
+  const [stats, setStats]             = useState(null);
+  const [loadingBatches, setLoadingBatches] = useState(true);
+  const [loading, setLoading]         = useState(false);
+  const [error, setError]             = useState(null);
+
+  useEffect(() => {
+    if (!fetchBatchesFn) { setLoadingBatches(false); return; }
+    fetchBatchesFn()
+      .then((data) => setBatches(data.map((b) => ({ value: String(b.id), label: b.label }))))
+      .catch((e) => setError(e.message))
+      .finally(() => setLoadingBatches(false));
+  }, []);
+
+  useEffect(() => {
+    if (!batchId) { setStats(null); return; }
+    setLoading(true);
+    setError(null);
+    fetchFn(batchId)
+      .then((data) => setStats(Array.isArray(data) ? data[0] : data))
+      .catch((e) => setError(e.message))
+      .finally(() => setLoading(false));
+  }, [batchId]);
+
+  return (
+    <Stack spacing="sm">
+      {fetchBatchesFn && (
+        <Select
+          label="Batch"
+          placeholder="Select batch…"
+          data={batches}
+          value={batchId}
+          onChange={setBatchId}
+          searchable
+          disabled={loadingBatches}
+          nothingFoundMessage="No batches with published results"
+          style={{ maxWidth: 340 }}
+        />
+      )}
+
+      {error && <Alert color="red" title="Error">{error}</Alert>}
+
+      {!batchId && !loading && (
+        <Text color="dimmed" size="sm">Select a batch to view placement statistics.</Text>
+      )}
+
+      {loading && <Loader />}
+
+      {stats && !loading && (
+        <Card withBorder radius="md" p="md">
+          <Text weight={700} size="lg" mb="md">
+            {stats.batch_label || `Batch ${stats.batch_year}`}
+          </Text>
+          <SimpleGrid cols={4} spacing="md" breakpoints={[{ maxWidth: 768, cols: 2 }]}>
+            <Card withBorder radius="sm" p="sm" style={{ textAlign: 'center' }}>
+              <Center>
+                <RingProgress
+                  size={80}
+                  thickness={8}
+                  sections={[{ value: stats.placement_rate || 0, color: 'green' }]}
+                  label={<Text size="xs" align="center">{stats.placement_rate || 0}%</Text>}
+                />
+              </Center>
+              <Text size="sm" align="center" mt={4}>Placed</Text>
+              <Text size="xs" color="dimmed" align="center">{stats.total_placed}/{stats.total_students}</Text>
+            </Card>
+            <Card withBorder radius="sm" p="sm" style={{ textAlign: 'center' }}>
+              <Text size="xl" weight={700}>{stats.total_companies}</Text>
+              <Text size="sm" color="dimmed">Companies</Text>
+            </Card>
+            <Card withBorder radius="sm" p="sm" style={{ textAlign: 'center' }}>
+              <Text size="xl" weight={700}>{stats.avg_ctc ? `${stats.avg_ctc} LPA` : '—'}</Text>
+              <Text size="sm" color="dimmed">Avg CTC</Text>
+            </Card>
+            <Card withBorder radius="sm" p="sm" style={{ textAlign: 'center' }}>
+              <Text size="xl" weight={700}>{stats.highest_ctc ? `${stats.highest_ctc} LPA` : '—'}</Text>
+              <Text size="sm" color="dimmed">Highest CTC</Text>
+            </Card>
+          </SimpleGrid>
+
+          {(stats.on_campus_placed !== undefined) && (
+            <Group spacing="xs" mt="md">
+              <Badge color="blue" variant="light">On-Campus: {stats.on_campus_placed}</Badge>
+              <Badge color="orange" variant="light">Off-Campus: {stats.off_campus_placed}</Badge>
+              <Badge color="green" variant="light">Total Placed: {stats.total_placed}</Badge>
+            </Group>
+          )}
+        </Card>
+      )}
+    </Stack>
+  );
+}

--- a/src/Modules/PlacementCell/components/StudentDashboard.jsx
+++ b/src/Modules/PlacementCell/components/StudentDashboard.jsx
@@ -1,0 +1,85 @@
+import React, { useEffect, useState } from 'react';
+import {
+  Card, Text, Badge, Group, Stack, Loader, Alert, SimpleGrid, Divider,
+} from '@mantine/core';
+import { fetchDashboard } from '../api';
+import JobCard from './JobCard';
+
+export default function StudentDashboard() {
+  const [data, setData]   = useState(null);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    fetchDashboard()
+      .then(setData)
+      .catch((e) => setError(e.message));
+  }, []);
+
+  if (error)  return <Alert color="red" title="Error">{error}</Alert>;
+  if (!data)  return <Loader />;
+
+  return (
+    <Stack spacing="md">
+      <Card withBorder radius="md" p="md">
+        <Group position="apart">
+          <Text weight={600} size="lg">My Placement Status</Text>
+          {data.live_cpi != null ? (
+            <Badge color="blue" size="lg">CPI: {data.live_cpi}</Badge>
+          ) : (
+            <Badge color="gray" size="lg">CPI: Not published yet</Badge>
+          )}
+        </Group>
+      </Card>
+
+      {data.announcements?.length > 0 && (
+        <>
+          <Text weight={600} size="md">Announcements</Text>
+          <Stack spacing="xs">
+            {data.announcements.map((a) => (
+              <Card key={a.id} withBorder radius="sm" p="sm" style={{ borderLeftColor: a.is_pinned ? '#228be6' : undefined, borderLeftWidth: a.is_pinned ? 3 : undefined }}>
+                <Text weight={600}>{a.title}</Text>
+                <Text size="sm" color="dimmed">{a.body}</Text>
+              </Card>
+            ))}
+          </Stack>
+        </>
+      )}
+
+      <Text weight={600} size="md">Upcoming Drives</Text>
+      {data.jobs?.length === 0 ? (
+        <Text color="dimmed">No active job openings at this time.</Text>
+      ) : (
+        <SimpleGrid cols={2} spacing="md" breakpoints={[{ maxWidth: 768, cols: 1 }]}>
+          {data.jobs.map((job) => <JobCard key={job.id} job={job} />)}
+        </SimpleGrid>
+      )}
+
+      {data.applications?.length > 0 && (
+        <>
+          <Divider />
+          <Text weight={600} size="md">Recent Applications</Text>
+          <Stack spacing="xs">
+            {data.applications.map((app) => (
+              <Card key={app.id} withBorder radius="sm" p="sm">
+                <Group position="apart">
+                  <div>
+                    <Text weight={600}>{app.company_name}</Text>
+                    <Text size="sm" color="dimmed">{app.role}</Text>
+                  </div>
+                  <Badge color={
+                    app.status === 'placed' ? 'green' :
+                    app.status === 'shortlisted' ? 'blue' :
+                    app.status === 'rejected' ? 'red' :
+                    app.status === 'withdrawn' ? 'gray' : 'yellow'
+                  }>
+                    {app.status}
+                  </Badge>
+                </Group>
+              </Card>
+            ))}
+          </Stack>
+        </>
+      )}
+    </Stack>
+  );
+}

--- a/src/Modules/PlacementCell/components/StudentProfile.jsx
+++ b/src/Modules/PlacementCell/components/StudentProfile.jsx
@@ -1,0 +1,95 @@
+import React, { useEffect, useState } from 'react';
+import {
+  Stack, TextInput, Switch, Button, Badge, Group, Text, Loader, Alert, Card,
+} from '@mantine/core';
+import { fetchStudentProfile, updateStudentProfile } from '../api';
+
+export default function StudentProfile() {
+  const [profile, setProfile]   = useState(null);
+  const [form, setForm]         = useState({ resume_url: '', linkedin_url: '', github_url: '', opted_out: false });
+  const [saving, setSaving]     = useState(false);
+  const [saved, setSaved]       = useState(false);
+  const [error, setError]       = useState(null);
+
+  useEffect(() => {
+    fetchStudentProfile()
+      .then((data) => {
+        setProfile(data);
+        setForm({
+          resume_url:   data.resume_url   || '',
+          linkedin_url: data.linkedin_url || '',
+          github_url:   data.github_url   || '',
+          opted_out:    data.opted_out    || false,
+        });
+      })
+      .catch((e) => setError(e.message));
+  }, []);
+
+  const handleSave = async () => {
+    setSaving(true);
+    setSaved(false);
+    setError(null);
+    try {
+      const updated = await updateStudentProfile(form);
+      setProfile(updated);
+      setSaved(true);
+    } catch (e) {
+      setError(e.message);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  if (!profile && !error) return <Loader />;
+  if (error && !profile)  return <Alert color="red" title="Error">{error}</Alert>;
+
+  return (
+    <Stack spacing="md" style={{ maxWidth: 520 }}>
+      <Card withBorder radius="md" p="md">
+        <Group position="apart">
+          <Text weight={600}>Placement Status</Text>
+          <Badge color={profile?.is_placed ? 'green' : 'gray'}>
+            {profile?.is_placed ? 'Placed' : 'Not Placed'}
+          </Badge>
+        </Group>
+        {profile?.live_cpi != null && (
+          <Text size="sm" color="dimmed" mt={4}>Published CPI: {profile.live_cpi}</Text>
+        )}
+      </Card>
+
+      <TextInput
+        label="Resume (Google Drive link)"
+        placeholder="https://drive.google.com/..."
+        value={form.resume_url}
+        onChange={(e) => setForm((f) => ({ ...f, resume_url: e.currentTarget.value }))}
+      />
+      <TextInput
+        label="LinkedIn URL"
+        placeholder="https://linkedin.com/in/..."
+        value={form.linkedin_url}
+        onChange={(e) => setForm((f) => ({ ...f, linkedin_url: e.currentTarget.value }))}
+      />
+      <TextInput
+        label="GitHub URL"
+        placeholder="https://github.com/..."
+        value={form.github_url}
+        onChange={(e) => setForm((f) => ({ ...f, github_url: e.currentTarget.value }))}
+      />
+      {profile?.opted_out ? (
+        <Alert color="orange" title="Opted Out of Placement">
+          You have opted out of the placement process. To revert this, please visit the Placement Cell office in person.
+        </Alert>
+      ) : (
+        <Switch
+          label="Opt out of placement process"
+          description="This action is permanent — you cannot undo it through this portal."
+          checked={form.opted_out}
+          onChange={(e) => { const v = e.currentTarget.checked; setForm((f) => ({ ...f, opted_out: v })); }}
+        />
+      )}
+      {error && <Alert color="red">{error}</Alert>}
+      {saved && <Alert color="green">Profile saved.</Alert>}
+      <Button onClick={handleSave} loading={saving}>Save Profile</Button>
+    </Stack>
+  );
+}

--- a/src/Modules/PlacementCell/index.jsx
+++ b/src/Modules/PlacementCell/index.jsx
@@ -1,0 +1,159 @@
+import React, { useState, useEffect } from 'react';
+import { Flex } from '@mantine/core';
+import { useSelector, useDispatch } from 'react-redux';
+import { setActiveTab_ } from '../../redux/moduleslice';
+
+import CustomBreadcrumbs from '../../components/Breadcrumbs';
+import ModuleTabs from '../../components/moduleTabs';
+
+import StudentDashboard    from './components/StudentDashboard';
+import JobList             from './components/JobList';
+import MyApplications      from './components/MyApplications';
+import StudentProfile      from './components/StudentProfile';
+import CompanyManager      from './components/CompanyManager';
+import JobPostManager      from './components/JobPostManager';
+import AllStudents         from './components/AllStudents';
+import AnnouncementManager from './components/AnnouncementManager';
+import PlacementStatistics from './components/PlacementStatistics';
+import ExportPanel         from './components/ExportPanel';
+import OffCampusManager    from './components/OffCampusManager';
+
+import {
+  fetchBatches, fetchAllStudents, fetchOfficerStats, exportPlacementData,
+  fetchChairmanStats, fetchChairmanBatches, fetchChairmanStudents, exportChairmanData,
+  fetchDeanBatches, fetchDeanStats, fetchDeanAnnouncements,
+} from './api';
+
+// ── Student ────────────────────────────────────────────────────────────────
+const STUDENT_TABS = [
+  { title: 'Dashboard' },
+  { title: 'Job Openings' },
+  { title: 'My Applications' },
+  { title: 'My Profile' },
+];
+const STUDENT_COMPONENTS = [StudentDashboard, JobList, MyApplications, StudentProfile];
+
+// ── Placement Officer ──────────────────────────────────────────────────────
+const OFFICER_TABS = [
+  { title: 'Students' },
+  { title: 'Off-Campus' },
+  { title: 'Companies' },
+  { title: 'Job Posts' },
+  { title: 'Announcements' },
+  { title: 'Statistics' },
+  { title: 'Export' },
+];
+
+// ── Chairman ───────────────────────────────────────────────────────────────
+const CHAIRMAN_TABS = [
+  { title: 'Students' },
+  { title: 'Statistics' },
+  { title: 'Export' },
+];
+
+// ── Dean / Faculty ─────────────────────────────────────────────────────────
+const DEAN_TABS = [
+  { title: 'Statistics' },
+  { title: 'Announcements' },
+];
+
+export default function PlacementCell() {
+  const role     = useSelector((state) => state.user.role);
+  const dispatch = useDispatch();
+
+  const [activeTab, setActiveTab] = useState('0');
+
+  let tabs;
+  if (role === 'student')                                            tabs = STUDENT_TABS;
+  else if (role === 'placement officer')                             tabs = OFFICER_TABS;
+  else if (role === 'placement_chairman' || role === 'placement chairman') tabs = CHAIRMAN_TABS;
+  else                                                               tabs = DEAN_TABS;
+
+  // Keep breadcrumb active-tab label in sync
+  useEffect(() => {
+    const idx = parseInt(activeTab, 10);
+    if (tabs[idx]) dispatch(setActiveTab_(tabs[idx].title));
+  }, [activeTab, tabs, dispatch]);
+
+  const handleTabChange = (val) => setActiveTab(val);
+
+  const idx = parseInt(activeTab, 10);
+
+  return (
+    <>
+      <CustomBreadcrumbs />
+      <Flex justify="space-between" align="center" mt="lg">
+        <ModuleTabs
+          tabs={tabs}
+          activeTab={activeTab}
+          setActiveTab={handleTabChange}
+        />
+      </Flex>
+
+      <div style={{ padding: '0 8px' }}>
+        {role === 'student' && (
+          <>
+            {idx === 0 && <StudentDashboard />}
+            {idx === 1 && <JobList />}
+            {idx === 2 && <MyApplications />}
+            {idx === 3 && <StudentProfile />}
+          </>
+        )}
+
+        {role === 'placement officer' && (
+          <>
+            {idx === 0 && <AllStudents fetchBatchesFn={fetchBatches} fetchStudentsFn={fetchAllStudents} />}
+            {idx === 1 && <OffCampusManager />}
+            {idx === 2 && <CompanyManager />}
+            {idx === 3 && <JobPostManager />}
+            {idx === 4 && <AnnouncementManager />}
+            {idx === 5 && <PlacementStatistics fetchFn={fetchOfficerStats} fetchBatchesFn={fetchBatches} />}
+            {idx === 6 && <ExportPanel exportFn={exportPlacementData} />}
+          </>
+        )}
+
+        {(role === 'placement_chairman' || role === 'placement chairman') && (
+          <>
+            {idx === 0 && <AllStudents fetchBatchesFn={fetchChairmanBatches} fetchStudentsFn={fetchChairmanStudents} />}
+            {idx === 1 && <PlacementStatistics fetchFn={fetchChairmanStats} fetchBatchesFn={fetchChairmanBatches} />}
+            {idx === 2 && <ExportPanel exportFn={exportChairmanData} label="Export Full Report" />}
+          </>
+        )}
+
+        {role !== 'student' && role !== 'placement officer' && role !== 'placement_chairman' && role !== 'placement chairman' && (
+          <>
+            {idx === 0 && <PlacementStatistics fetchFn={fetchDeanStats} fetchBatchesFn={fetchDeanBatches} />}
+            {idx === 1 && <DeanAnnouncements />}
+          </>
+        )}
+      </div>
+    </>
+  );
+}
+
+function DeanAnnouncements() {
+  const [items, setItems] = React.useState([]);
+  const [error, setError] = React.useState(null);
+
+  React.useEffect(() => {
+    fetchDeanAnnouncements().then(setItems).catch((e) => setError(e.message));
+  }, []);
+
+  if (error) return <div style={{ color: 'red' }}>{error}</div>;
+
+  return (
+    <div>
+      {items.length === 0 && <p style={{ color: '#868e96' }}>No announcements.</p>}
+      {items.map((a) => (
+        <div key={a.id} style={{
+          borderLeft: a.is_pinned ? '3px solid #228be6' : '3px solid #dee2e6',
+          padding: '12px 16px', marginBottom: 8, background: '#f8f9fa', borderRadius: 4,
+        }}>
+          <strong>{a.title}</strong>
+          <p style={{ margin: '4px 0', fontSize: 14 }}>{a.body}</p>
+          <span style={{ fontSize: 12, color: '#868e96' }}>{new Date(a.posted_at).toLocaleDateString()}</span>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/components/sidebarContent.jsx
+++ b/src/components/sidebarContent.jsx
@@ -108,7 +108,7 @@ function SidebarContent({ isCollapsed, toggleSidebar }) {
       label: "Placement Cell",
       id: "placement_cell",
       icon: <PlacementIcon size={18} />,
-      url: "/",
+      url: "/placement-cell",
     },
     {
       label: "Department Portal",

--- a/src/routes/placementRoutes/index.jsx
+++ b/src/routes/placementRoutes/index.jsx
@@ -1,0 +1,41 @@
+import { host } from '../globalRoutes';
+
+// Student
+export const STU_DASHBOARD_URL       = `${host}/placement-cell/api/stu/dashboard/`;
+export const STU_JOBS_URL            = `${host}/placement-cell/api/stu/jobs/`;
+export const STU_JOB_DETAIL_URL      = (id) => `${host}/placement-cell/api/stu/jobs/${id}/`;
+export const STU_JOB_APPLY_URL       = (id) => `${host}/placement-cell/api/stu/jobs/${id}/apply/`;
+export const STU_APPLICATIONS_URL    = `${host}/placement-cell/api/stu/applications/`;
+export const STU_WITHDRAW_URL        = (id) => `${host}/placement-cell/api/stu/applications/${id}/withdraw/`;
+export const STU_PROFILE_URL         = `${host}/placement-cell/api/stu/profile/`;
+
+// Placement Officer
+export const OFC_COMPANIES_URL       = `${host}/placement-cell/api/officer/companies/`;
+export const OFC_COMPANY_URL         = (id) => `${host}/placement-cell/api/officer/companies/${id}/`;
+export const OFC_JOBS_URL            = `${host}/placement-cell/api/officer/jobs/`;
+export const OFC_JOB_URL             = (id) => `${host}/placement-cell/api/officer/jobs/${id}/`;
+export const OFC_JOB_TOGGLE_URL      = (id) => `${host}/placement-cell/api/officer/jobs/${id}/toggle/`;
+export const OFC_APPLICANTS_URL      = (id) => `${host}/placement-cell/api/officer/jobs/${id}/applicants/`;
+export const OFC_APP_STATUS_URL      = (id) => `${host}/placement-cell/api/officer/applications/${id}/status/`;
+export const OFC_BULK_STATUS_URL     = `${host}/placement-cell/api/officer/applications/bulk-status/`;
+export const OFC_BATCHES_URL           = `${host}/placement-cell/api/officer/batches/`;
+export const OFC_STUDENTS_URL          = (batchId) => `${host}/placement-cell/api/officer/students/?batch_id=${batchId}`;
+export const OFC_STUDENT_UPDATE_URL    = `${host}/placement-cell/api/officer/students/update/`;
+export const OFC_EXPORT_URL          = `${host}/placement-cell/api/officer/export/`;
+export const OFC_ANNOUNCEMENTS_URL   = `${host}/placement-cell/api/officer/announcements/`;
+export const OFC_ANNOUNCEMENT_URL    = (id) => `${host}/placement-cell/api/officer/announcements/${id}/`;
+export const OFC_STATS_URL           = `${host}/placement-cell/api/officer/statistics/`;
+export const OFC_STATS_REFRESH_URL   = `${host}/placement-cell/api/officer/statistics/refresh/`;
+export const OFC_OFFCAMPUS_URL       = `${host}/placement-cell/api/officer/offcampus/`;
+export const OFC_OFFCAMPUS_ITEM_URL  = (id) => `${host}/placement-cell/api/officer/offcampus/${id}/`;
+
+// Placement Chairman
+export const CHM_STATS_URL           = `${host}/placement-cell/api/chairman/statistics/`;
+export const CHM_BATCHES_URL         = `${host}/placement-cell/api/chairman/batches/`;
+export const CHM_STUDENTS_URL        = (batchId) => `${host}/placement-cell/api/chairman/students/?batch_id=${batchId}`;
+export const CHM_EXPORT_URL          = `${host}/placement-cell/api/chairman/export/`;
+
+// Dean / Faculty
+export const DEAN_BATCHES_URL        = `${host}/placement-cell/api/dean/batches/`;
+export const DEAN_STATS_URL          = `${host}/placement-cell/api/dean/statistics/`;
+export const DEAN_ANNOUNCEMENTS_URL  = `${host}/placement-cell/api/dean/announcements/`;


### PR DESCRIPTION
## Summary

- Adds a complete Placement Cell frontend module under `src/Modules/PlacementCell/` with role-based tab views for Student, Placement Officer, Placement Chairman, and Dean/Faculty
- UI is built to match the existing production design system — uses shared `ModuleTabs` (caret-arrow scrollable tabs) and `CustomBreadcrumbs` exactly as used in the Academics and Programme Curriculum modules
- Table styling matches production: blue header (`#C5E2F6` / `#3498db`), alternating row colors (`#E6F7FF` / `#fff`), rounded bordered container

## Features by role

**Student**
- Dashboard: active eligible job cards with deadline badges (red/orange/green), announcements, live CPI card
- Job Openings: browse and apply; external apply-link support (tracks application in DB and opens external portal)
- My Applications: color-coded status badges (applied / shortlisted / placed / rejected / withdrawn), withdraw button
- My Profile: resume URL, LinkedIn, GitHub links; opted-out is one-way (shows permanent alert once set, cannot revert via portal)

**Placement Officer**
- Students: batch select → table of students with live published CPI, placement status (On-Campus / Off-Campus / Placed / Not Placed), CPI filter (min/max), Export to XLSX/PDF; per-row Actions menu to mark placed or set opted-out
- Off-Campus: record and delete off-campus placements (students automatically marked as placed in statistics)
- Companies: full CRUD for company records
- Job Posts: create/edit/activate/deactivate job posts; optional CTC/Stipend; optional external apply link; per-job applicant list with bulk status update
- Announcements: create (with pin option) and delete announcements
- Statistics: batch-wise live stats — total students, placed, on-campus vs off-campus breakdown, companies visited, avg/highest CTC
- Export: download placement data as XLSX or PDF

**Placement Chairman** — Students, Statistics, Export (read + export only)

**Dean/Faculty** — Statistics, Announcements (read-only)

## Other changes
- `src/components/sidebarContent.jsx`: fixed sidebar URL from `"/"` to `"/placement-cell"`
- `src/routes/placementRoutes/index.jsx`: all API route constants
- `src/App.jsx`: registered `/placement-cell` route

## Test plan
- [x] Login as student → verify Dashboard, Job Openings, My Applications, My Profile tabs appear with caret arrows
- [x] Login as placement officer → verify all 7 tabs appear; create a job post; apply as student; update status in Applicants
- [x] Add an off-campus placement → verify student appears as "Off-Campus" in Students tab
- [x] Set opted-out as student → verify it cannot be reverted via the portal
- [x] Apply via external link → verify application is tracked in DB and external URL opens
- [x] Statistics tab → select a batch → verify live counts appear
- [x] Login as dean → verify only Statistics and Announcements tabs appear