### PR TITLE
feat: Update CSV download filename extraction to use content-disposition header

### DIFF
--- a/src/Modules/Examination/generateTranscript.jsx
+++ b/src/Modules/Examination/generateTranscript.jsx
@@ -147,17 +147,9 @@ export default function GenerateTranscript() {
         headers: { Authorization: `Token ${token}` },
         responseType: "blob",
       });
-      const batchOption = formOptions.batches.find(
-        (opt) => opt.value === formData.batch,
-      );
-      const semesterOption = formOptions.semesters.find(
-        (opt) => opt.value === formData.semester,
-      );
-      const batchLabel = batchOption ? batchOption.label : formData.batch;
-      const semesterLabel = semesterOption
-        ? semesterOption.label
-        : `Semester ${semester_no}`;
-      const fileName = `${batchLabel}_${semesterLabel}.xlsx`;
+      const contentDisposition = response.headers["content-disposition"];
+      const filenameMatch = contentDisposition?.match(/filename="([^"]+)"/);
+      const fileName = filenameMatch ? filenameMatch[1] : "student_grades.xlsx";
       const url = window.URL.createObjectURL(new Blob([response.data]));
       const link = document.createElement("a");
       link.href = url;


### PR DESCRIPTION
This pull request updates the way the downloaded transcript file is named in the `GenerateTranscript` component. Instead of constructing the filename based on selected batch and semester labels, the code now extracts the filename directly from the `Content-Disposition` header of the server response. This ensures that the filename used for the download matches what the backend specifies, improving consistency and reliability.

- File download behavior:
  * [`src/Modules/Examination/generateTranscript.jsx`](diffhunk://#diff-eb64166af1cae11cef3b8fa7bface7eb7e246d3e149ee84c85f8539e4a73ffddL150-R152): Changed filename determination logic to extract the filename from the `Content-Disposition` response header, defaulting to `student_grades.xlsx` if not present.