### PR TITLE
Fix blank page on test server: drop manualChunks that split the React runtime

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -5,40 +5,12 @@ import react from "@vitejs/plugin-react";
 export default defineConfig({
   plugins: [react()],
   build: {
+    // Let Rollup chunk automatically. A hand-rolled manualChunks that split the
+    // React runtime (react / react-dom / scheduler / use-sync-external-store /
+    // react-redux) across separate chunks caused an init-order crash in the
+    // production build ("Cannot read properties of undefined (reading
+    // 'useSyncExternalStore')") and a blank page. The big load-time win comes
+    // from the lazy-loaded placement tabs, which split regardless of this.
     chunkSizeWarningLimit: 1500,
-    rollupOptions: {
-      output: {
-        // Split heavy third-party libraries into their own long-term-cacheable
-        // chunks instead of one multi-megabyte bundle, so the browser can load
-        // them in parallel and reuse them across route/code-split chunks.
-        manualChunks(id) {
-          if (!id.includes("node_modules")) return undefined;
-          if (id.includes("react-big-calendar") || id.includes("date-fns")) {
-            return "vendor-calendar";
-          }
-          if (id.includes("mantine-react-table") || id.includes("@tanstack")) {
-            return "vendor-table";
-          }
-          if (id.includes("@mantine")) return "vendor-mantine";
-          if (
-            id.includes("xhtml2pdf") ||
-            id.includes("jspdf") ||
-            id.includes("html2canvas") ||
-            id.includes("dompurify")
-          ) {
-            return "vendor-pdf";
-          }
-          if (
-            id.includes("/react/") ||
-            id.includes("/react-dom/") ||
-            id.includes("react-router") ||
-            id.includes("redux")
-          ) {
-            return "vendor-react";
-          }
-          return "vendor";
-        },
-      },
-    },
   },
 });


### PR DESCRIPTION
Hotfix for the blank page on the test server. The custom Vite manualChunks split react/react-dom/scheduler/use-sync-external-store/react-redux across vendor chunks that initialised out of order in the production build ("Cannot read properties of undefined (reading 'useSyncExternalStore')"). Drop manualChunks; Rollup orders the React runtime correctly. Lazy-loaded tabs still code-split.