### PR TITLE
Add authorization token to API requests in admin forms

### DIFF
--- a/src/Modules/Program_curriculum/Acad_admin/Admin_add_course_proposal_form.jsx
+++ b/src/Modules/Program_curriculum/Acad_admin/Admin_add_course_proposal_form.jsx
@@ -128,7 +128,10 @@ function Admin_add_course_proposal_form() {
     try {
       const response = await fetch(apiUrl, {
         method: "POST",
-        headers: { "Content-Type": "application/json" },
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Token ${localStorage.getItem("authToken")}`,
+        },
         body: JSON.stringify(payload),
       });
 

--- a/src/Modules/Program_curriculum/Acad_admin/Admin_add_programme_form.jsx
+++ b/src/Modules/Program_curriculum/Acad_admin/Admin_add_programme_form.jsx
@@ -107,8 +107,7 @@ function Admin_add_programme_form() {
 
   const handleSubmit = async (values) => {
     const apiUrl = `${host}/programme_curriculum/api/admin_add_programme/`;
-    const token = localStorage.getItem("token");
-    
+
     localStorage.removeItem("AdminProgrammesCache");
     localStorage.removeItem("AdminProgrammesTimestamp");
     localStorage.setItem("AdminProgrammesCachechange", "true");
@@ -117,6 +116,9 @@ function Admin_add_programme_form() {
       setLoading(true);
       const response = await fetch(apiUrl, {
         method: "POST",
+        headers: {
+          Authorization: `Token ${localStorage.getItem("authToken")}`,
+        },
         body: JSON.stringify(values),
       });
 

--- a/src/Modules/Program_curriculum/Acad_admin/Admin_edit_course_instructor_form.jsx
+++ b/src/Modules/Program_curriculum/Acad_admin/Admin_edit_course_instructor_form.jsx
@@ -116,7 +116,10 @@ function Admin_edit_course_instructor() {
         `${host}/programme_curriculum/api/admin_update_course_instructor/${id}/`,
         {
           method: "POST",
-          headers: { "Content-Type": "application/json" },
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Token ${localStorage.getItem("authToken")}`,
+          },
           body: JSON.stringify({
             course_id: values.courseName,
             instructor_id: values.instructor,

--- a/src/Modules/Program_curriculum/Acad_admin/Admin_edit_programme_form.jsx
+++ b/src/Modules/Program_curriculum/Acad_admin/Admin_edit_programme_form.jsx
@@ -75,6 +75,9 @@ function Admin_edit_programme_form() {
         `${host}/programme_curriculum/api/admin_edit_programme/${id}/`,
         {
           method: "POST",
+          headers: {
+            Authorization: `Token ${localStorage.getItem("authToken")}`,
+          },
           body: JSON.stringify(submitData),
         },
       );

--- a/src/Modules/Program_curriculum/api/api.js
+++ b/src/Modules/Program_curriculum/api/api.js
@@ -424,8 +424,14 @@ export const fetchBatchData = async (batch_id) => {
 
 export const fetchFacultiesData = async () => {
   try {
+    const token = localStorage.getItem("authToken");
     const response = await axios.get(
       `${BASE_URL}/programme_curriculum/api/admin_faculties/`,
+      {
+        headers: {
+          Authorization: `Token ${token}`,
+        },
+      },
     );
     return response.data.faculties;
   } catch (error) {


### PR DESCRIPTION
This pull request updates several admin-related forms and API calls in the program curriculum module to ensure that API requests include the proper authentication token in the headers. This change standardizes authentication across the admin forms and API utilities, improving security and consistency.

**Authentication header updates:**

* Added the `Authorization: Token ...` header using the `authToken` value from `localStorage` to all relevant `fetch` calls in the following components:
  - `Admin_add_course_proposal_form.jsx` (`Admin_add_course_proposal_form`)
  - `Admin_add_programme_form.jsx` (`Admin_add_programme_form`)
  - `Admin_edit_course_instructor_form.jsx` (`Admin_edit_course_instructor`)
  - `Admin_edit_programme_form.jsx` (`Admin_edit_programme_form`)

**API utility update:**

* Updated `fetchFacultiesData` in `api.js` to include the authentication token in the request headers for fetching faculty data.

**Cleanup:**

* Removed an unused `token` variable from `Admin_add_programme_form.jsx` for clarity.