### PR TITLE
Display total number of students in grades preview for components

### DIFF
--- a/src/Modules/Academic/StudentCourses.jsx
+++ b/src/Modules/Academic/StudentCourses.jsx
@@ -101,9 +101,15 @@ export default function StudentCourses() {
       setStudentData(data);
 
       if (data.current_semester) {
+        // Derive the semester type from the semester number's parity so the
+        // value always matches a dropdown option (odd no -> Odd Semester,
+        // even no -> Even Semester). The backend's month-based type can
+        // otherwise conflict with an even/odd semester number and leave the
+        // Select empty.
+        const no = Number(data.current_semester.semester_no);
         setSelectedSemester({
-          no: data.current_semester.semester_no,
-          type: data.current_semester.semester_type
+          no,
+          type: no % 2 === 1 ? "Odd Semester" : "Even Semester",
         });
       }
     } catch (err) {

--- a/src/Modules/Examination/submitGrades.jsx
+++ b/src/Modules/Examination/submitGrades.jsx
@@ -427,9 +427,13 @@ function SubmitGrades() {
         {showPreview && previewData && (
           <Box ref={previewRef} mt="md">
             <h2>Grades Preview</h2>
+            <Text fw={600} mb="sm">
+              Total Students: {previewData.length}
+            </Text>
             <Table highlightOnHover>
               <thead>
                 <tr>
+                  <th>S. No</th>
                   <th>Roll No</th>
                   <th>Name</th>
                   <th>Branch</th>
@@ -442,6 +446,7 @@ function SubmitGrades() {
               <tbody>
                 {previewData.map((row, index) => (
                   <tr key={index} style={{ backgroundColor: row.is_registered ? "inherit" : "#ffe6e6" }}>
+                    <td>{index + 1}</td>
                     <td>{row.roll_no}</td>
                     <td>{row.name}</td>
                     <td>{row.branch || '-'}</td>

--- a/src/Modules/Examination/submitGradesProf.jsx
+++ b/src/Modules/Examination/submitGradesProf.jsx
@@ -414,6 +414,9 @@ export default function SubmitGradesProf() {
       ) : (
         <Box ref={previewRef} mt="md">
           <Title order={3} mb="sm">Grades Preview</Title>
+          <Text fw={600} mb="sm">
+            Total Students: {previewData.length}
+          </Text>
           <Table highlightOnHover>
             <thead>
               <tr>


### PR DESCRIPTION
This pull request introduces improvements to the student course selection and grade submission preview features. The main changes ensure better consistency in semester selection and enhance the grade preview tables by adding student counts and serial numbers.

Enhancements to grade submission previews:

* Added a "Total Students" count above the grades preview table in both `SubmitGrades` and `SubmitGradesProf` components for better visibility. [[1]](diffhunk://#diff-bd10a073fda0754247fc934baecd4b56852af23fe76900d1b34c5f16671e369dR430-R436) [[2]](diffhunk://#diff-c2dc4d87e47d374fa38d2d66a00e9d7a89d8629635a1cf6f8d5399d269088d2aR417-R419)
* Added a serial number ("S. No") column to the grades preview table in `SubmitGrades`, making it easier to reference students in the list.

Improvements to semester selection logic:

* Updated the semester selection in `StudentCourses` to derive the semester type ("Odd Semester" or "Even Semester") from the parity of the semester number, ensuring consistency with dropdown options and preventing mismatches with backend data.