### PR TITLE
Examination: add Summer Semester to Download Grades semester dropdown

### DIFF
--- a/src/Modules/Examination/checkResultsProf.jsx
+++ b/src/Modules/Examination/checkResultsProf.jsx
@@ -26,6 +26,7 @@ export default function GradesDownloadPage() {
   const semesterOptions = [
     { value: "Odd Semester", label: "Odd" },
     { value: "Even Semester", label: "Even" },
+    { value: "Summer Semester", label: "Summer" },
   ];
   
   const programmeTypes = [


### PR DESCRIPTION
This pull request makes a small update to the `GradesDownloadPage` component by adding "Summer Semester" as an option in the `semesterOptions` dropdown.

* Added "Summer Semester" to the `semesterOptions` array to allow users to select it when downloading grades.