### PR TITLE
Examination: show grade-submission Section only for UG

### DIFF
--- a/src/Modules/Examination/submitGradesProf.jsx
+++ b/src/Modules/Examination/submitGradesProf.jsx
@@ -51,8 +51,11 @@ export default function SubmitGradesProf() {
 
   // Sections the selected course is allotted in (empty => elective, no section).
   // For faculty this is their own assigned section(s); for acadadmin, all of them.
+  // Sections apply only to UG; PG/PhD have no sections.
   const selectedCourseSections =
-    courseOptions.find((c) => c.value === course)?.sections || [];
+    programmeType === "UG"
+      ? courseOptions.find((c) => c.value === course)?.sections || []
+      : [];
 
   // A sectioned course needs a section chosen before submit.
   const sectionMissing = selectedCourseSections.length > 0 && !section;
@@ -61,10 +64,10 @@ export default function SubmitGradesProf() {
   // acadadmin selects manually. (If a faculty teaches multiple sections of the
   // same course, they still choose which one.)
   useEffect(() => {
-    if (isAcadadmin) return;
+    if (isAcadadmin || programmeType !== "UG") return;
     const secs = courseOptions.find((c) => c.value === course)?.sections || [];
     if (secs.length === 1) setSection(secs[0]);
-  }, [course, courseOptions, isAcadadmin]);
+  }, [course, courseOptions, isAcadadmin, programmeType]);
 
   useEffect(() => {
     async function fetchAcademicYears() {
@@ -345,7 +348,10 @@ export default function SubmitGradesProf() {
                 placeholder="Select Programme Type"
                 data={programmeTypes}
                 value={programmeType}
-                onChange={setProgrammeType}
+                onChange={(v) => {
+                  setProgrammeType(v);
+                  setSection("");
+                }}
                 disabled={loading}
                 required
               />


### PR DESCRIPTION
Pairs with the backend change (FusionIIIT/Fusion#1935) gating section handling to UG.

## Changes
- **Section dropdown appears only when Programme Type is UG** — PG/PhD have no sections.
- Section is not auto-filled for non-UG and is cleared when Programme Type changes, so the "select a section" requirement no longer blocks PG/PhD grade submission.

Verified: builds clean.