### PR TITLE
Use a dynamic API host for external-reviewer invitation/review links

### DIFF
--- a/src/routes/academicRoutes/index.jsx
+++ b/src/routes/academicRoutes/index.jsx
@@ -1,4 +1,4 @@
-import { host } from "../globalRoutes";
+import { host, dynamicApiHost } from "../globalRoutes";
 
 export const calendarRoute = `${host}/aims/api/calendar/`;
 export const editCalendarRoute = `${host}/aims/api/calendar/update/`;
@@ -232,11 +232,13 @@ export const deanSendInvitationsRoute = `${host}/academic-procedures/api/thesis/
 export const directorDashboardRoute = `${host}/academic-procedures/api/thesis/director-dashboard/`;
 export const directorApproveRoute = `${host}/academic-procedures/api/thesis/director-approve/`;
 
-// External Reviewer (token-based)
+// External Reviewer (token-based). Reached via emailed links from arbitrary
+// networks -- uses dynamicApiHost, not host, so it works regardless of what
+// domain the page is actually opened on.
 export const invitationActionRoute = (token, action) =>
-  `${host}/academic-procedures/api/invitation/${token}/${action}/`;
+  `${dynamicApiHost}/academic-procedures/api/invitation/${token}/${action}/`;
 export const reviewDetailRoute = (token) =>
-  `${host}/academic-procedures/api/review/${token}/`;
+  `${dynamicApiHost}/academic-procedures/api/review/${token}/`;
 
 // ============================================================================
 // PhD Comprehensive Examination

--- a/src/routes/globalRoutes/index.jsx
+++ b/src/routes/globalRoutes/index.jsx
@@ -1,9 +1,11 @@
 export const host = "http://127.0.0.1:8000";
+export const dynamicApiHost = `${window.location.protocol}//${window.location.hostname}:8000`;
+
 export const authRoute = `${host}/api/auth/me`;
 export const loginRoute = `${host}/api/auth/login/`;
 export const mediaRoute = `${host}/media/`;
 
 // OTP-based password reset
-export const passwordResetSendOtp   = `${host}/api/auth/password-reset/send-otp/`;
+export const passwordResetSendOtp = `${host}/api/auth/password-reset/send-otp/`;
 export const passwordResetVerifyOtp = `${host}/api/auth/password-reset/verify-otp/`;
-export const passwordResetReset     = `${host}/api/auth/password-reset/reset/`;
+export const passwordResetReset = `${host}/api/auth/password-reset/reset/`;


### PR DESCRIPTION
## Summary
- Follow-up to #271. The external-reviewer invitation/review-detail links were built from the hardcoded `host` constant (`127.0.0.1:8000`), which only works when the frontend and backend happen to be on that exact host.
- These links are emailed to professors and opened from arbitrary networks, so derive the API host from `window.location` instead (`dynamicApiHost`), matching whatever domain/port the frontend was actually loaded through.

## Test plan
- [ ] Load the app from a non-localhost domain and confirm an emailed invitation/review link resolves to the correct API host