### PR TITLE
Section Assignment roll-range + cross-section backlog registration UI

### DIFF
--- a/src/Modules/Academic/SectionAssignment.jsx
+++ b/src/Modules/Academic/SectionAssignment.jsx
@@ -197,6 +197,12 @@ function SectionAssignment() {
       );
       return next;
     });
+    showNotification({
+      title: mode === "select" ? "Range selected" : "Range unselected",
+      message: `${matches.length} student(s) ${mode === "select" ? "added to" : "removed from"} selection.`,
+      color: mode === "select" ? "indigo" : "gray",
+      autoClose: 2000,
+    });
   };
 
   // Majority roll prefix = this discipline's native students; the rest are
@@ -222,6 +228,12 @@ function SectionAssignment() {
         mode === "select" ? next.add(s.roll_no) : next.delete(s.roll_no),
       );
       return next;
+    });
+    showNotification({
+      title: mode === "select" ? "Transfers selected" : "Transfers unselected",
+      message: `${transferRolls.length} transferred student(s) ${mode === "select" ? "added to" : "removed from"} selection.`,
+      color: mode === "select" ? "orange" : "gray",
+      autoClose: 2000,
     });
   };
 

--- a/src/Modules/Academic/SectionAssignment.jsx
+++ b/src/Modules/Academic/SectionAssignment.jsx
@@ -43,6 +43,10 @@ function SectionAssignment() {
   const [otherSection, setOtherSection] = useState("");
   const [saving, setSaving] = useState(false);
 
+  // Roll-number range for bulk select/unselect.
+  const [rangeFrom, setRangeFrom] = useState("");
+  const [rangeTo, setRangeTo] = useState("");
+
   const token = localStorage.getItem("authToken");
   const authHeader = { headers: { Authorization: `Token ${token}` } };
 
@@ -127,6 +131,96 @@ function SectionAssignment() {
       const next = new Set(prev);
       if (next.has(roll)) next.delete(roll);
       else next.add(roll);
+      return next;
+    });
+  };
+
+  // Split a roll into its prefix + trailing number ("21BCS007" -> {21BCS, 7}).
+  const parseRoll = (roll) => {
+    const s = String(roll || "")
+      .trim()
+      .toUpperCase();
+    const m = s.match(/^(.*?)(\d+)$/);
+    return m
+      ? { prefix: m[1], num: parseInt(m[2], 10) }
+      : { prefix: s, num: NaN };
+  };
+
+  // Select/unselect listed students in [from, to]. Prefix-aware, so a
+  // transferred-in student who kept a different roll prefix (e.g. 21BME015 in a
+  // CSE list) is NOT matched by a numeric range.
+  const applyRange = (mode) => {
+    const f = parseRoll(rangeFrom);
+    const t = parseRoll(rangeTo);
+    if (Number.isNaN(f.num) || Number.isNaN(t.num)) {
+      showNotification({
+        title: "Enter a valid range",
+        message: "Provide both From and To roll numbers.",
+        color: "yellow",
+      });
+      return;
+    }
+    const lo = Math.min(f.num, t.num);
+    const hi = Math.max(f.num, t.num);
+    // Prefix from the inputs if given, else the most common prefix in the list.
+    let prefix = f.prefix || t.prefix;
+    if (!prefix) {
+      const counts = {};
+      students.forEach((s) => {
+        const p = parseRoll(s.roll_no).prefix;
+        counts[p] = (counts[p] || 0) + 1;
+      });
+      prefix =
+        Object.keys(counts).sort((a, b) => counts[b] - counts[a])[0] || "";
+    }
+    const matches = students.filter((s) => {
+      const p = parseRoll(s.roll_no);
+      return (
+        !Number.isNaN(p.num) &&
+        p.prefix === prefix &&
+        p.num >= lo &&
+        p.num <= hi
+      );
+    });
+    if (matches.length === 0) {
+      showNotification({
+        title: "No matches",
+        message: `No ${prefix || ""} students in that roll-number range.`,
+        color: "yellow",
+      });
+      return;
+    }
+    setSelected((prev) => {
+      const next = new Set(prev);
+      matches.forEach((s) =>
+        mode === "select" ? next.add(s.roll_no) : next.delete(s.roll_no),
+      );
+      return next;
+    });
+  };
+
+  // Majority roll prefix = this discipline's native students; the rest are
+  // transferred-in (kept a foreign roll prefix) and are handled as one group.
+  const nativePrefix = (() => {
+    const counts = {};
+    students.forEach((s) => {
+      const p = parseRoll(s.roll_no).prefix;
+      counts[p] = (counts[p] || 0) + 1;
+    });
+    return Object.keys(counts).sort((a, b) => counts[b] - counts[a])[0] || "";
+  })();
+
+  const transferRolls = students.filter(
+    (s) => parseRoll(s.roll_no).prefix !== nativePrefix,
+  );
+
+  const applyTransfers = (mode) => {
+    if (transferRolls.length === 0) return;
+    setSelected((prev) => {
+      const next = new Set(prev);
+      transferRolls.forEach((s) =>
+        mode === "select" ? next.add(s.roll_no) : next.delete(s.roll_no),
+      );
       return next;
     });
   };
@@ -251,6 +345,57 @@ function SectionAssignment() {
             Assign Section{selected.size > 0 ? ` (${selected.size})` : ""}
           </Button>
         </Flex>
+
+        {students.length > 0 && (
+          <Flex gap="md" align="flex-end" wrap="wrap" mt="md">
+            <TextInput
+              label="From roll no."
+              placeholder="e.g. 21BCS001 or 1"
+              value={rangeFrom}
+              onChange={(e) => setRangeFrom(e.currentTarget.value)}
+              style={{ flex: 1, minWidth: 150 }}
+            />
+            <TextInput
+              label="To roll no."
+              placeholder="e.g. 21BCS050 or 50"
+              value={rangeTo}
+              onChange={(e) => setRangeTo(e.currentTarget.value)}
+              style={{ flex: 1, minWidth: 150 }}
+            />
+            <Button
+              variant="light"
+              color="indigo"
+              onClick={() => applyRange("select")}
+            >
+              Select range
+            </Button>
+            <Button
+              variant="light"
+              color="gray"
+              onClick={() => applyRange("unselect")}
+            >
+              Unselect range
+            </Button>
+            {transferRolls.length > 0 && (
+              <>
+                <Button
+                  variant="light"
+                  color="orange"
+                  onClick={() => applyTransfers("select")}
+                >
+                  Select transfers ({transferRolls.length})
+                </Button>
+                <Button
+                  variant="light"
+                  color="gray"
+                  onClick={() => applyTransfers("unselect")}
+                >
+                  Unselect transfers
+                </Button>
+              </>
+            )}
+          </Flex>
+        )}
       </Paper>
 
       {loadingStudents ? (

--- a/src/Modules/Academic/StudentAddCourse.jsx
+++ b/src/Modules/Academic/StudentAddCourse.jsx
@@ -56,10 +56,30 @@ export default function StudentAddCourse() {
   if (error)   return <Alert color="red">{error}</Alert>;
   if (!slots.length) return <Text>No slots available for adding courses.</Text>;
 
+  const courseOf = (s) =>
+    (s.courses || []).find(c => String(c.id) === s.selectedCourse);
+
+  // A course not running in the student's own section needs a running section picked.
+  const needsSection = (s) => {
+    const c = courseOf(s);
+    return !!c && !c.own_section_running && (c.sections || []).length > 0;
+  };
+
   const pickCourse = (idx, val) => {
-    setSlots(slots.map((s, i) =>
-      i === idx ? { ...s, selectedCourse: val } : s
-    ));
+    setSlots(slots.map((s, i) => {
+      if (i !== idx) return s;
+      const course = (s.courses || []).find(c => String(c.id) === val);
+      // Auto-pick when the course runs in exactly one (other) section.
+      let selectedSection = '';
+      if (course && !course.own_section_running && (course.sections || []).length === 1) {
+        selectedSection = String(course.sections[0].course_instructor_id);
+      }
+      return { ...s, selectedCourse: val, selectedSection };
+    }));
+  };
+
+  const pickSection = (idx, val) => {
+    setSlots(slots.map((s, i) => (i === idx ? { ...s, selectedSection: val } : s)));
   };
 
   const toSubmit = slots.filter(s => s.selectedCourse && s.selectedCourse !== '');
@@ -70,17 +90,31 @@ export default function StudentAddCourse() {
       showNotification({ title: 'Auth Error', message: 'No token', color: 'red' });
       return;
     }
-    setSubmitting(true);
-
     const selectedSlots = slots.filter(s => s.selectedCourse && s.selectedCourse !== '');
+
+    const missingSection = selectedSlots.find(s => needsSection(s) && !s.selectedSection);
+    if (missingSection) {
+      const c = courseOf(missingSection);
+      showNotification({
+        title: 'Section required',
+        message: `Select a section for ${c ? c.code : 'the course'} — it isn't running in your section.`,
+        color: 'yellow',
+      });
+      return;
+    }
+
+    setSubmitting(true);
 
     try {
       await Promise.all(
         selectedSlots.map(s =>
           axios.post(studentAddCourseRoute,
-            { 
+            {
               slot_id: s.id,
-              course_id: parseInt(s.selectedCourse, 10)
+              course_id: parseInt(s.selectedCourse, 10),
+              ...(s.selectedSection
+                ? { course_instructor_id: parseInt(s.selectedSection, 10) }
+                : {}),
             },
             { headers: { Authorization: `Token ${token}` } }
           )
@@ -137,6 +171,21 @@ export default function StudentAddCourse() {
                   onChange={val => pickCourse(i, val)}
                   clearable
                 />
+                {needsSection(s) && (
+                  <Select
+                    mt="xs"
+                    placeholder="Select section…"
+                    description="Not running in your section — pick a running one"
+                    data={courseOf(s).sections.map(sec => ({
+                      value: String(sec.course_instructor_id),
+                      label: sec.section
+                        ? `Section ${sec.section} — ${sec.instructor}`
+                        : sec.instructor,
+                    }))}
+                    value={s.selectedSection || ''}
+                    onChange={val => pickSection(i, val)}
+                  />
+                )}
               </td>
             </tr>
           ))}

--- a/src/Modules/Academic/StudentCourses.jsx
+++ b/src/Modules/Academic/StudentCourses.jsx
@@ -66,6 +66,7 @@ export default function StudentCourses() {
     course_id: null,
     academic_year: null,
     registration_type: null,
+    course_instructor_id: null,
     old_course: null,
   });
 
@@ -184,6 +185,8 @@ export default function StudentCourses() {
     form.append("course_id", course_id);
     form.append("academic_year", academic_year);
     form.append("registration_type", registration_type);
+    if (newCourse.course_instructor_id)
+      form.append("course_instructor_id", newCourse.course_instructor_id);
     if (old_course) form.append("old_course", old_course);
 
     setLoading(true);
@@ -200,6 +203,7 @@ export default function StudentCourses() {
           course_id: null,
           academic_year: null,
           registration_type: null,
+          course_instructor_id: null,
           old_course: null,
         });
         showNotification({
@@ -253,19 +257,39 @@ export default function StudentCourses() {
     }
   };
 
-  const handleSlotChange = async (slotId) => {
-    setNewCourse((p) => ({ ...p, courseslot_id: slotId, course_id: null }));
+  // Fetch a slot's courses. Passing the term makes the API include each course's
+  // running sections, so the admin can pick one for a cross-section backlog/improvement.
+  const fetchSlotCourses = async (slotId, academicYear, semesterType) => {
+    if (!slotId) return;
     const token = localStorage.getItem("authToken");
+    let url = `${getCoursesRoute}?courseslot_id=${slotId}`;
+    if (academicYear && semesterType) {
+      url += `&academic_year=${encodeURIComponent(academicYear)}&semester_type=${encodeURIComponent(semesterType)}`;
+    }
     try {
-      const { data } = await axios.get(
-        `${getCoursesRoute}?courseslot_id=${slotId}`,
-        { headers: { Authorization: `Token ${token}` } }
-      );
+      const { data } = await axios.get(url, {
+        headers: { Authorization: `Token ${token}` },
+      });
       setSlotCourses(data);
     } catch {
       setError("Failed to load courses");
     }
   };
+
+  const handleSlotChange = async (slotId) => {
+    setNewCourse((p) => ({
+      ...p,
+      courseslot_id: slotId,
+      course_id: null,
+      course_instructor_id: null,
+    }));
+    fetchSlotCourses(slotId, newCourse.academic_year, newCourse.semester_type);
+  };
+
+  // Running sections of the selected course (present when the term is chosen).
+  const courseSections =
+    slotCourses.find((c) => String(c.id) === String(newCourse.course_id))
+      ?.sections || [];
 
   const filteredDetails =
     studentData?.details.filter(
@@ -421,9 +445,31 @@ export default function StudentCourses() {
           placeholder="Select academic year"
           data={academicYears.map((y) => ({ value: y, label: y }))}
           value={newCourse.academic_year}
-          onChange={(v) => setNewCourse((p) => ({ ...p, academic_year: v }))}
+          onChange={(v) => {
+            setNewCourse((p) => ({ ...p, academic_year: v, course_instructor_id: null }));
+            fetchSlotCourses(newCourse.courseslot_id, v, newCourse.semester_type);
+          }}
           mb="sm"
         />
+        {courseSections.length > 0 && (
+          <Select
+            label="Section"
+            placeholder="Select section"
+            description="Running section — required for a backlog/improvement in another section"
+            data={courseSections.map((sec) => ({
+              value: String(sec.course_instructor_id),
+              label: sec.section
+                ? `Section ${sec.section} — ${sec.instructor}`
+                : sec.instructor,
+            }))}
+            value={newCourse.course_instructor_id}
+            onChange={(v) =>
+              setNewCourse((p) => ({ ...p, course_instructor_id: v }))
+            }
+            mb="sm"
+            clearable
+          />
+        )}
         <Select
           label="Registration Type"
           placeholder="Select type"


### PR DESCRIPTION
Frontend for the section roll-range helper and cross-section backlog/improvement registration.

## Section Assignment
- **From / To roll-no** range with **Select range / Unselect range** — prefix-aware, so a transferred-in student who kept a foreign roll prefix (e.g. `21BME…` now in CSE) isn't caught by a `1–50` range.
- **Select transfers (N) / Unselect transfers** — one-click bulk action for the other-prefix (transferred-in) students, shown only when the list has any.

## Cross-section backlog/improvement
- **Student Add Course** and acadadmin **Student Courses**: a **Section** picker appears when the chosen backlog/improvement course isn't running in the student's own section (auto-selects when only one section runs it; required before submit). Passed to the backend as `course_instructor_id`.

Backend counterpart: FusionIIIT/Fusion PR (prod/acad-react).