### PR TITLE
Add semester-wise filtering to Admin dashboards and Registered Courses

### DIFF
--- a/src/Modules/Academic/AdminAddDashboard.jsx
+++ b/src/Modules/Academic/AdminAddDashboard.jsx
@@ -32,6 +32,7 @@ const generateAcademicYears = () => {
 export default function AdminAddDashboard() {
   const [year, setYear] = useState('');
   const [semester, setSemester] = useState('');
+  const [semesterNo, setSemesterNo] = useState('');
   const [requests, setRequests] = useState([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(null);
@@ -92,18 +93,35 @@ export default function AdminAddDashboard() {
     [requests]
   );
 
+  // Distinct semesters across all requests, for the semester-wise filter.
+  const semesterOptions = useMemo(
+    () => Array.from(new Set(requests.map(r => r.semester).filter(s => s != null)))
+      .sort((a, b) => a - b)
+      .map(s => ({ value: String(s), label: `Semester ${s}` })),
+    [requests]
+  );
+
+  const visiblePending = useMemo(
+    () => semesterNo ? pendingRequests.filter(r => String(r.semester) === semesterNo) : pendingRequests,
+    [pendingRequests, semesterNo]
+  );
+
   const filteredProcessedRequests = useMemo(
-    () => statusFilter ? processedRequests.filter(r => r.status === statusFilter) : processedRequests,
-    [processedRequests, statusFilter]
+    () => processedRequests
+      .filter(r => (statusFilter ? r.status === statusFilter : true))
+      .filter(r => (semesterNo ? String(r.semester) === semesterNo : true)),
+    [processedRequests, statusFilter, semesterNo]
   );
 
   const toggleSelectAll = useCallback(() => {
-    if (selectedIds.size === pendingRequests.length && pendingRequests.length > 0) {
-      setSelectedIds(new Set());
-    } else {
-      setSelectedIds(new Set(pendingRequests.map(r => r.id)));
-    }
-  }, [selectedIds.size, pendingRequests]);
+    const allVisibleSelected =
+      visiblePending.length > 0 && visiblePending.every(r => selectedIds.has(r.id));
+    setSelectedIds(prev => {
+      const next = new Set(prev);
+      visiblePending.forEach(r => (allVisibleSelected ? next.delete(r.id) : next.add(r.id)));
+      return next;
+    });
+  }, [selectedIds, visiblePending]);
 
   const handleAction = useCallback(async (action) => {
     if (selectedIds.size === 0) {
@@ -314,6 +332,15 @@ export default function AdminAddDashboard() {
               value={semester}
               onChange={setSemester}
             />
+            <Select
+              label="Semester"
+              placeholder="All semesters"
+              data={semesterOptions}
+              value={semesterNo}
+              onChange={setSemesterNo}
+              clearable
+              disabled={semesterOptions.length === 0}
+            />
           </Group>
 
           <Group position="left" spacing="xs">
@@ -397,12 +424,13 @@ export default function AdminAddDashboard() {
                     <tr>
                       <th style={{ width: 50 }}>
                         <Checkbox
-                          checked={selectedIds.size === pendingRequests.length && pendingRequests.length > 0}
+                          checked={visiblePending.length > 0 && visiblePending.every(r => selectedIds.has(r.id))}
                           onChange={toggleSelectAll}
-                          indeterminate={selectedIds.size > 0 && selectedIds.size < pendingRequests.length}
+                          indeterminate={visiblePending.some(r => selectedIds.has(r.id)) && !visiblePending.every(r => selectedIds.has(r.id))}
                         />
                       </th>
                       <th>Student</th>
+                      <th>Sem</th>
                       <th>Slot</th>
                       <th>Course</th>
                       <th>Status</th>
@@ -411,7 +439,7 @@ export default function AdminAddDashboard() {
                     </tr>
                   </thead>
                   <tbody>
-                    {pendingRequests.map(r => (
+                    {visiblePending.map(r => (
                       <tr key={r.id}>
                         <td>
                           <Checkbox
@@ -425,6 +453,7 @@ export default function AdminAddDashboard() {
                             <Text size="xs" color="dimmed">{r.student_name}</Text>
                           )}
                         </td>
+                        <td>{r.semester ?? '-'}</td>
                         <td>{r.slot}</td>
                         <td>
                           <Text size="sm">{r.course}</Text>
@@ -475,6 +504,7 @@ export default function AdminAddDashboard() {
                   <thead>
                     <tr>
                       <th>Student</th>
+                      <th>Sem</th>
                       <th>Slot</th>
                       <th>Course</th>
                       <th>
@@ -508,6 +538,7 @@ export default function AdminAddDashboard() {
                             <Text size="xs" color="dimmed">{r.student_name}</Text>
                           )}
                         </td>
+                        <td>{r.semester ?? '-'}</td>
                         <td>{r.slot}</td>
                         <td>
                           <Text size="sm">{r.course}</Text>

--- a/src/Modules/Academic/AdminDropDashboard.jsx
+++ b/src/Modules/Academic/AdminDropDashboard.jsx
@@ -32,6 +32,7 @@ const generateAcademicYears = () => {
 export default function AdminDropDashboard() {
   const [year, setYear] = useState('');
   const [semester, setSemester] = useState('');
+  const [semesterNo, setSemesterNo] = useState('');
   const [requests, setRequests] = useState([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(null);
@@ -92,18 +93,35 @@ export default function AdminDropDashboard() {
     [requests]
   );
 
+  // Distinct semesters across all requests, for the semester-wise filter.
+  const semesterOptions = useMemo(
+    () => Array.from(new Set(requests.map(r => r.semester).filter(s => s != null)))
+      .sort((a, b) => a - b)
+      .map(s => ({ value: String(s), label: `Semester ${s}` })),
+    [requests]
+  );
+
+  const visiblePending = useMemo(
+    () => semesterNo ? pendingRequests.filter(r => String(r.semester) === semesterNo) : pendingRequests,
+    [pendingRequests, semesterNo]
+  );
+
   const filteredProcessedRequests = useMemo(
-    () => statusFilter ? processedRequests.filter(r => r.status === statusFilter) : processedRequests,
-    [processedRequests, statusFilter]
+    () => processedRequests
+      .filter(r => (statusFilter ? r.status === statusFilter : true))
+      .filter(r => (semesterNo ? String(r.semester) === semesterNo : true)),
+    [processedRequests, statusFilter, semesterNo]
   );
 
   const toggleSelectAll = useCallback(() => {
-    if (selectedIds.size === pendingRequests.length && pendingRequests.length > 0) {
-      setSelectedIds(new Set());
-    } else {
-      setSelectedIds(new Set(pendingRequests.map(r => r.id)));
-    }
-  }, [selectedIds.size, pendingRequests]);
+    const allVisibleSelected =
+      visiblePending.length > 0 && visiblePending.every(r => selectedIds.has(r.id));
+    setSelectedIds(prev => {
+      const next = new Set(prev);
+      visiblePending.forEach(r => (allVisibleSelected ? next.delete(r.id) : next.add(r.id)));
+      return next;
+    });
+  }, [selectedIds, visiblePending]);
 
   const handleAction = useCallback(async (action) => {
     if (selectedIds.size === 0) {
@@ -295,6 +313,15 @@ export default function AdminDropDashboard() {
               value={semester}
               onChange={setSemester}
             />
+            <Select
+              label="Semester"
+              placeholder="All semesters"
+              data={semesterOptions}
+              value={semesterNo}
+              onChange={setSemesterNo}
+              clearable
+              disabled={semesterOptions.length === 0}
+            />
           </Group>
 
           <Group position="left" spacing="xs">
@@ -378,12 +405,13 @@ export default function AdminDropDashboard() {
                     <tr>
                       <th style={{ width: 50 }}>
                         <Checkbox
-                          checked={selectedIds.size === pendingRequests.length && pendingRequests.length > 0}
+                          checked={visiblePending.length > 0 && visiblePending.every(r => selectedIds.has(r.id))}
                           onChange={toggleSelectAll}
-                          indeterminate={selectedIds.size > 0 && selectedIds.size < pendingRequests.length}
+                          indeterminate={visiblePending.some(r => selectedIds.has(r.id)) && !visiblePending.every(r => selectedIds.has(r.id))}
                         />
                       </th>
                       <th>Student</th>
+                      <th>Sem</th>
                       <th>Slot</th>
                       <th>Course</th>
                       <th>Status</th>
@@ -392,7 +420,7 @@ export default function AdminDropDashboard() {
                     </tr>
                   </thead>
                   <tbody>
-                    {pendingRequests.map(r => (
+                    {visiblePending.map(r => (
                       <tr key={r.id}>
                         <td>
                           <Checkbox
@@ -406,6 +434,7 @@ export default function AdminDropDashboard() {
                             <Text size="xs" color="dimmed">{r.student_name}</Text>
                           )}
                         </td>
+                        <td>{r.semester ?? '-'}</td>
                         <td>{r.slot}</td>
                         <td>
                           <Text size="sm">{r.course}</Text>
@@ -456,6 +485,7 @@ export default function AdminDropDashboard() {
                   <thead>
                     <tr>
                       <th>Student</th>
+                      <th>Sem</th>
                       <th>Slot</th>
                       <th>Course</th>
                       <th>
@@ -489,6 +519,7 @@ export default function AdminDropDashboard() {
                             <Text size="xs" color="dimmed">{r.student_name}</Text>
                           )}
                         </td>
+                        <td>{r.semester ?? '-'}</td>
                         <td>{r.slot}</td>
                         <td>
                           <Text size="sm">{r.course}</Text>

--- a/src/Modules/Academic/AdminReplacementDashboard.jsx
+++ b/src/Modules/Academic/AdminReplacementDashboard.jsx
@@ -34,6 +34,7 @@ const generateAcademicYears = () => {
 export default function AdminReplacementDashboard() {
   const [year, setYear] = useState('');
   const [semester, setSemester] = useState('');
+  const [semesterNo, setSemesterNo] = useState('');
   const [requests, setRequests] = useState([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(null);
@@ -53,14 +54,30 @@ export default function AdminReplacementDashboard() {
     [requests]
   );
 
+  // Distinct semesters across all requests (pending + processed), for the semester-wise filter.
+  const semesterOptions = useMemo(
+    () => Array.from(new Set(requests.map(r => r.semester).filter(s => s != null)))
+      .sort((a, b) => a - b)
+      .map(s => ({ value: String(s), label: `Semester ${s}` })),
+    [requests]
+  );
+
+  // Pending requests after applying the semester-wise filter (empty = all).
+  const visiblePendingRequests = useMemo(
+    () => semesterNo ? pendingRequests.filter(r => String(r.semester) === semesterNo) : pendingRequests,
+    [pendingRequests, semesterNo]
+  );
+
   const processedRequests = useMemo(
     () => requests.filter(r => r.status !== 'Pending'),
     [requests]
   );
 
   const filteredProcessedRequests = useMemo(
-    () => statusFilter ? processedRequests.filter(r => r.status === statusFilter) : processedRequests,
-    [processedRequests, statusFilter]
+    () => processedRequests
+      .filter(r => (statusFilter ? r.status === statusFilter : true))
+      .filter(r => (semesterNo ? String(r.semester) === semesterNo : true)),
+    [processedRequests, statusFilter, semesterNo]
   );
 
   const rejectedRequests = useMemo(
@@ -105,10 +122,10 @@ export default function AdminReplacementDashboard() {
       return;
     }
 
-    if (pendingRequests.length === 0) {
+    if (selectedPendingIds.size === 0) {
       showNotification({
-        title: 'No Pending Requests',
-        message: 'There are no pending requests to allocate.',
+        title: 'No requests selected',
+        message: 'Select the requests you want to allot, then click Start Allotment.',
         color: 'yellow',
       });
       return;
@@ -120,17 +137,19 @@ export default function AdminReplacementDashboard() {
       return;
     }
 
+    const ids = Array.from(selectedPendingIds);
     setAllocating(true);
     axios.post(allotReplacementCoursesRoute,
-      { academic_year: year, semester_type: semester },
+      { academic_year: year, semester_type: semester, request_ids: ids },
       { headers: { Authorization: `Token ${token}` } }
     )
     .then(() => {
       showNotification({
         title: 'Allocation Complete',
-        message: 'All pending requests processed.',
+        message: `${ids.length} selected request(s) processed.`,
         color: 'green'
       });
+      setSelectedPendingIds(new Set());
       fetchRequests(); // Refresh after allocation
     })
     .catch(err => {
@@ -160,12 +179,19 @@ export default function AdminReplacementDashboard() {
   }, []);
 
   const toggleSelectAllPending = useCallback(() => {
-    if (selectedPendingIds.size === pendingRequests.length && pendingRequests.length > 0) {
-      setSelectedPendingIds(new Set());
-    } else {
-      setSelectedPendingIds(new Set(pendingRequests.map(r => r.id)));
-    }
-  }, [selectedPendingIds.size, pendingRequests]);
+    const allVisibleSelected =
+      visiblePendingRequests.length > 0 &&
+      visiblePendingRequests.every(r => selectedPendingIds.has(r.id));
+    setSelectedPendingIds(prev => {
+      const next = new Set(prev);
+      if (allVisibleSelected) {
+        visiblePendingRequests.forEach(r => next.delete(r.id));
+      } else {
+        visiblePendingRequests.forEach(r => next.add(r.id));
+      }
+      return next;
+    });
+  }, [selectedPendingIds, visiblePendingRequests]);
 
   const toggleSelectAllRejected = useCallback(() => {
     if (selectedProcessedIds.size === rejectedRequests.length && rejectedRequests.length > 0) {
@@ -351,13 +377,14 @@ export default function AdminReplacementDashboard() {
         <tr>
           <th style={{ width: 50 }}>
             <Checkbox
-              checked={selectedPendingIds.size === data.length && data.length > 0}
+              checked={data.length > 0 && data.every(r => selectedPendingIds.has(r.id))}
               onChange={toggleSelectAllPending}
-              indeterminate={selectedPendingIds.size > 0 && selectedPendingIds.size < data.length}
+              indeterminate={data.some(r => selectedPendingIds.has(r.id)) && !data.every(r => selectedPendingIds.has(r.id))}
             />
           </th>
           <th>S. No.</th>
           <th>Student</th>
+          <th>Sem</th>
           <th>Slot</th>
           <th>Old</th>
           <th>New</th>
@@ -380,6 +407,7 @@ export default function AdminReplacementDashboard() {
               <Text size="sm" weight={500}>{r.student}</Text>
               <Text size="xs" color="dimmed">{r.student_name}</Text>
             </td>
+            <td>{r.semester ?? '-'}</td>
             <td>{r.slot}</td>
             <td>
               <Text size="sm" weight={500}>{r.old_course}</Text>
@@ -424,6 +452,7 @@ export default function AdminReplacementDashboard() {
           )}
           <th>S. No.</th>
           <th>Student</th>
+          <th>Sem</th>
           <th>Slot</th>
           <th>Old</th>
           <th>New</th>
@@ -468,6 +497,7 @@ export default function AdminReplacementDashboard() {
               <Text size="sm" weight={500}>{r.student}</Text>
               <Text size="xs" color="dimmed">{r.student_name}</Text>
             </td>
+            <td>{r.semester ?? '-'}</td>
             <td>{r.slot}</td>
             <td>
               <Text size="sm" weight={500}>{r.old_course}</Text>
@@ -527,6 +557,15 @@ export default function AdminReplacementDashboard() {
               value={semester}
               onChange={setSemester}
             />
+            <Select
+              label="Semester"
+              placeholder="All semesters"
+              data={semesterOptions}
+              value={semesterNo}
+              onChange={setSemesterNo}
+              clearable
+              disabled={semesterOptions.length === 0}
+            />
           </Group>
 
           <Group position="left" spacing="xs">
@@ -538,14 +577,14 @@ export default function AdminReplacementDashboard() {
             >
               Refresh
             </Button>
-            <Button 
-              size="sm" 
-              color="green" 
-              onClick={handleAllocate} 
+            <Button
+              size="sm"
+              color="green"
+              onClick={handleAllocate}
               loading={allocating}
-              disabled={!year || !semester || pendingRequests.length === 0}
+              disabled={!year || !semester || selectedPendingIds.size === 0}
             >
-              Start Allotment
+              Start Allotment ({selectedPendingIds.size})
             </Button>
           </Group>
         </Stack>
@@ -597,7 +636,7 @@ export default function AdminReplacementDashboard() {
                     </Button>
                   </Group>
                 </Group>
-                {renderPendingTable(pendingRequests)}
+                {renderPendingTable(visiblePendingRequests)}
               </Card>
             ) : (
               <Alert color="blue">No pending replacement requests.</Alert>

--- a/src/Modules/Academic/AdminSwayamDashboard.jsx
+++ b/src/Modules/Academic/AdminSwayamDashboard.jsx
@@ -35,7 +35,21 @@ const AdminSwayamDashboard = () => {
   const [selectedIds, setSelectedIds] = useState([]);
   const [academicYear, setAcademicYear] = useState('');
   const [semesterType, setSemesterType] = useState('');
+  const [semesterNo, setSemesterNo] = useState('');
   const academicYears = useMemo(() => generateAcademicYears(), []);
+
+  // Distinct semesters in the current request list, for the semester-wise filter.
+  const semesterOptions = useMemo(
+    () => Array.from(new Set(requests.map(r => r.semester?.semester_no).filter(s => s != null)))
+      .sort((a, b) => a - b)
+      .map(s => ({ value: String(s), label: `Semester ${s}` })),
+    [requests]
+  );
+
+  const visibleRequests = useMemo(
+    () => semesterNo ? requests.filter(r => String(r.semester?.semester_no) === semesterNo) : requests,
+    [requests, semesterNo]
+  );
 
   useEffect(() => {
     fetchRequests();
@@ -204,11 +218,9 @@ const AdminSwayamDashboard = () => {
   };
 
   const toggleSelectAll = () => {
-    if (selectedIds.length === requests.length) {
-      setSelectedIds([]);
-    } else {
-      setSelectedIds(requests.map(r => r.id));
-    }
+    const allVisibleSelected =
+      visibleRequests.length > 0 && visibleRequests.every(r => selectedIds.includes(r.id));
+    setSelectedIds(allVisibleSelected ? [] : visibleRequests.map(r => r.id));
   };
 
   const toggleSelect = (id) => {
@@ -244,8 +256,8 @@ const AdminSwayamDashboard = () => {
         key: 'checkbox',
         header: (
           <Checkbox
-            checked={selectedIds.length === requests.length && requests.length > 0}
-            indeterminate={selectedIds.length > 0 && selectedIds.length < requests.length}
+            checked={visibleRequests.length > 0 && visibleRequests.every(r => selectedIds.includes(r.id))}
+            indeterminate={visibleRequests.some(r => selectedIds.includes(r.id)) && !visibleRequests.every(r => selectedIds.includes(r.id))}
             onChange={toggleSelectAll}
           />
         ),
@@ -260,6 +272,7 @@ const AdminSwayamDashboard = () => {
       { key: 'student', header: 'Student Name', render: (req) => req.student.name },
       { key: 'roll', header: 'Roll No', render: (req) => req.student.roll_no },
       { key: 'batch', header: 'Batch', render: (req) => req.student.batch },
+      { key: 'sem', header: 'Sem', render: (req) => req.semester?.semester_no ?? '-' },
     ];
 
     if (activeRequestTab === 'replace') {
@@ -358,7 +371,7 @@ const AdminSwayamDashboard = () => {
           </tr>
         </thead>
         <tbody>
-          {requests.map((req, index) => (
+          {visibleRequests.map((req, index) => (
             <tr key={req.id}>
               {columns.map((col) => (
                 <td key={col.key}>{col.render(req, index)}</td>
@@ -389,6 +402,15 @@ const AdminSwayamDashboard = () => {
               data={SEMESTER_CHOICES}
               value={semesterType}
               onChange={setSemesterType}
+            />
+            <Select
+              label="Semester"
+              placeholder="All semesters"
+              data={semesterOptions}
+              value={semesterNo}
+              onChange={setSemesterNo}
+              clearable
+              disabled={semesterOptions.length === 0}
             />
           </Group>
           <Group position="left">

--- a/src/Modules/Academic/RegisteredCourses.jsx
+++ b/src/Modules/Academic/RegisteredCourses.jsx
@@ -28,6 +28,12 @@ export default function RegisteredCourses() {
   const user = useSelector((state) => state.user);
 
   useEffect(() => {
+    // Student-only view: skip the student endpoints until the role resolves to 'student' (avoids a 403 when mounted for other roles).
+    if (user?.role !== "student") {
+      setLoading(false);
+      return;
+    }
+
     const fetchStudentProfile = async () => {
       const getValueSafely = (obj, paths) => {
         for (const path of paths) {


### PR DESCRIPTION
This pull request adds a semester-wise filter to the admin dashboards for Add, Drop, and Replacement requests, improving usability for administrators handling large numbers of requests. The changes introduce a new semester filter dropdown, update table displays to include semester information, and ensure selection actions (like "select all") are scoped to the currently visible (filtered) requests.

The most important changes are:

**Semester-wise Filtering and UI Enhancements**
- Added a `Select` dropdown for filtering requests by semester number (`semesterNo`) on all three dashboards: Add, Drop, and Replacement. The dropdown is dynamically populated with available semesters from the requests data. [[1]](diffhunk://#diff-1c027926242a055c4168d303533271435adc89014b06cfa6a33afd9ee66f2379R335-R343) [[2]](diffhunk://#diff-4f65f78d038e188fd29212a2486645962eb433e6b3dd241a0be9a46114a2a1a1R316-R324) [[3]](diffhunk://#diff-42150aa124a052b4bfc337df0367fceb9a52708b20cf7df1da90e1cf116b9394R560-R568)
- Updated the pending and processed requests tables to display the semester number as a new column for each request, making it easier to identify the semester context of each entry. [[1]](diffhunk://#diff-1c027926242a055c4168d303533271435adc89014b06cfa6a33afd9ee66f2379L400-R433) [[2]](diffhunk://#diff-1c027926242a055c4168d303533271435adc89014b06cfa6a33afd9ee66f2379R456) [[3]](diffhunk://#diff-1c027926242a055c4168d303533271435adc89014b06cfa6a33afd9ee66f2379R507) [[4]](diffhunk://#diff-1c027926242a055c4168d303533271435adc89014b06cfa6a33afd9ee66f2379R541) [[5]](diffhunk://#diff-4f65f78d038e188fd29212a2486645962eb433e6b3dd241a0be9a46114a2a1a1L381-R414) [[6]](diffhunk://#diff-4f65f78d038e188fd29212a2486645962eb433e6b3dd241a0be9a46114a2a1a1R437) [[7]](diffhunk://#diff-4f65f78d038e188fd29212a2486645962eb433e6b3dd241a0be9a46114a2a1a1R488) [[8]](diffhunk://#diff-4f65f78d038e188fd29212a2486645962eb433e6b3dd241a0be9a46114a2a1a1R522) [[9]](diffhunk://#diff-42150aa124a052b4bfc337df0367fceb9a52708b20cf7df1da90e1cf116b9394L354-R387) [[10]](diffhunk://#diff-42150aa124a052b4bfc337df0367fceb9a52708b20cf7df1da90e1cf116b9394R410) [[11]](diffhunk://#diff-42150aa124a052b4bfc337df0367fceb9a52708b20cf7df1da90e1cf116b9394R455) [[12]](diffhunk://#diff-42150aa124a052b4bfc337df0367fceb9a52708b20cf7df1da90e1cf116b9394R500)

**Filtering Logic and Data Handling**
- Introduced logic to filter both pending and processed requests by the selected semester, ensuring only relevant requests are shown when a semester is selected. [[1]](diffhunk://#diff-1c027926242a055c4168d303533271435adc89014b06cfa6a33afd9ee66f2379R96-R124) [[2]](diffhunk://#diff-4f65f78d038e188fd29212a2486645962eb433e6b3dd241a0be9a46114a2a1a1R96-R124) [[3]](diffhunk://#diff-42150aa124a052b4bfc337df0367fceb9a52708b20cf7df1da90e1cf116b9394R57-R80)
- Updated "select all" and indeterminate checkbox logic so that selection actions only apply to the currently visible (filtered) requests, preventing accidental selection of requests outside the current filter. [[1]](diffhunk://#diff-1c027926242a055c4168d303533271435adc89014b06cfa6a33afd9ee66f2379R96-R124) [[2]](diffhunk://#diff-1c027926242a055c4168d303533271435adc89014b06cfa6a33afd9ee66f2379L400-R433) [[3]](diffhunk://#diff-1c027926242a055c4168d303533271435adc89014b06cfa6a33afd9ee66f2379L414-R442) [[4]](diffhunk://#diff-4f65f78d038e188fd29212a2486645962eb433e6b3dd241a0be9a46114a2a1a1R96-R124) [[5]](diffhunk://#diff-4f65f78d038e188fd29212a2486645962eb433e6b3dd241a0be9a46114a2a1a1L381-R414) [[6]](diffhunk://#diff-4f65f78d038e188fd29212a2486645962eb433e6b3dd241a0be9a46114a2a1a1L395-R423) [[7]](diffhunk://#diff-42150aa124a052b4bfc337df0367fceb9a52708b20cf7df1da90e1cf116b9394L163-R194) [[8]](diffhunk://#diff-42150aa124a052b4bfc337df0367fceb9a52708b20cf7df1da90e1cf116b9394L354-R387)

**Replacement Dashboard Workflow Improvements**
- Improved the workflow for replacement requests: the "Start Allotment" action now only processes selected requests (not all pending), and the notification messaging and API payload reflect the number of selected requests. [[1]](diffhunk://#diff-42150aa124a052b4bfc337df0367fceb9a52708b20cf7df1da90e1cf116b9394L108-R128) [[2]](diffhunk://#diff-42150aa124a052b4bfc337df0367fceb9a52708b20cf7df1da90e1cf116b9394R140-R152)

These changes collectively enhance the admin dashboards by making them more scalable and user-friendly, especially when handling requests across multiple semesters.